### PR TITLE
fix: add exit call for graceful shutdown on stop signal

### DIFF
--- a/wyoming_microsoft_tts/__main__.py
+++ b/wyoming_microsoft_tts/__main__.py
@@ -24,6 +24,7 @@ def handle_stop_signal(*args):
     """Handle shutdown signal and set the stop event."""
     _LOGGER.info("Received stop signal. Shutting down...")
     stop_event.set()
+    exit(0)
 
 
 def parse_arguments():


### PR DESCRIPTION
Implement an exit call to ensure the application shuts down gracefully when a stop signal is received.