### PR TITLE
feat: support multilingual voices from the secondaryLocaleList

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def microsoft_tts(configuration):
     args = SimpleNamespace(
         subscription_key=os.environ.get("SPEECH_KEY"),
         service_region=os.environ.get("SPEECH_REGION"),
+        download_dir="/tmp/",
         **configuration
     )
     return MicrosoftTTS(args)

--- a/wyoming_microsoft_tts/__main__.py
+++ b/wyoming_microsoft_tts/__main__.py
@@ -3,7 +3,6 @@ import asyncio
 import contextlib
 import logging
 import os
-import re
 import signal
 from functools import partial
 from typing import Any
@@ -79,11 +78,6 @@ def validate_args(args):
     if not args.service_region or not args.subscription_key:
         raise ValueError(
             "Both --service-region and --subscription-key must be provided either as command-line arguments or environment variables."
-        )
-    # Reinstate key validation with more flexibility to accommodate complex keys
-    if not re.match(r"^[A-Za-z0-9\-_]{40,}$", args.subscription_key):
-        _LOGGER.warning(
-            "The subscription key does not match the expected format but will attempt to initialize."
         )
 
 

--- a/wyoming_microsoft_tts/download.py
+++ b/wyoming_microsoft_tts/download.py
@@ -33,7 +33,7 @@ def _quote_url(url: str) -> str:
 
 
 def transform_voices_files(response):
-    """Transform the voices.json file from the Microsoft API to the format used by Piper."""
+    """Transform the voices.json file from the Microsoft API to the format used by Wyoming."""
     json_response = json.load(response)
     voices = {}
     for entry in json_response:
@@ -55,6 +55,25 @@ def transform_voices_files(response):
                 "speaker_id_map": {},
                 "aliases": [],
             }
+            if "SecondaryLocaleList" in entry:
+                for secondary_locale in entry["SecondaryLocaleList"]:
+                    country = countries.get(alpha_2=secondary_locale.split("-")[1])
+                    voices[entry["ShortName"].replace(entry["Locale"], secondary_locale)] = {
+                        "key": entry["ShortName"],
+                        "name": entry["LocalName"],
+                        "language": {
+                            "code": secondary_locale,
+                            "family": secondary_locale.split("-")[0],
+                            "region": country.alpha_2,
+                            "name_native": secondary_locale,
+                            "name_english": secondary_locale,
+                            "country_english": country.name,
+                        },
+                        "quality": entry["VoiceType"],
+                        "num_speakers": 1,
+                        "speaker_id_map": {},
+                        "aliases": [],
+                    }
         except Exception as e:
             _LOGGER.error("Failed to parse voice %s", entry["ShortName"])
             _LOGGER.debug("%s: %s", entry["ShortName"], e)

--- a/wyoming_microsoft_tts/download.py
+++ b/wyoming_microsoft_tts/download.py
@@ -116,7 +116,7 @@ def get_voices(
     voices_embedded = _DIR / "voices.json"
     _LOGGER.debug("Loading %s", voices_embedded)
     with open(voices_embedded, encoding="utf-8") as voices_file:
-        return json.load(voices_file)
+        return transform_voices_files(voices_file)
 
 
 def find_voice(name: str, download_dir: Union[str, Path]) -> dict[str, Any]:

--- a/wyoming_microsoft_tts/microsoft_tts.py
+++ b/wyoming_microsoft_tts/microsoft_tts.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import azure.cognitiveservices.speech as speechsdk
 
+from .download import get_voices
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -25,13 +27,16 @@ class MicrosoftTTS:
         output_dir.mkdir(parents=True, exist_ok=True)
         self.output_dir = output_dir
 
+        self.voices = get_voices(args.download_dir)
+
     def synthesize(self, text, voice=None):
         """Synthesize text to speech."""
         _LOGGER.debug(f"Requested TTS for [{text}]")
         if voice is None:
             voice = self.args.voice
 
-        self.speech_config.speech_synthesis_voice_name = voice
+        # Convert the requested voice to the key microsoft use.
+        self.speech_config.speech_synthesis_voice_name = self.voices[voice]["key"]
 
         file_name = self.output_dir / f"{time.monotonic_ns()}.wav"
         audio_config = speechsdk.audio.AudioOutputConfig(filename=str(file_name))

--- a/wyoming_microsoft_tts/voices.json
+++ b/wyoming_microsoft_tts/voices.json
@@ -1,7234 +1,12419 @@
-{
-    "af-ZA-AdriNeural": {
-        "key": "af-ZA-AdriNeural",
-        "name": "Adri",
-        "language": {
-            "code": "af-ZA",
-            "family": "af",
-            "region": "ZA",
-            "name_native": "Afrikaans (South Africa)",
-            "name_english": "Afrikaans (South Africa)",
-            "country_english": "South Africa"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "af-ZA-WillemNeural": {
-        "key": "af-ZA-WillemNeural",
-        "name": "Willem",
-        "language": {
-            "code": "af-ZA",
-            "family": "af",
-            "region": "ZA",
-            "name_native": "Afrikaans (South Africa)",
-            "name_english": "Afrikaans (South Africa)",
-            "country_english": "South Africa"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "am-ET-MekdesNeural": {
-        "key": "am-ET-MekdesNeural",
-        "name": "\u1218\u1245\u12f0\u1235",
-        "language": {
-            "code": "am-ET",
-            "family": "am",
-            "region": "ET",
-            "name_native": "Amharic (Ethiopia)",
-            "name_english": "Amharic (Ethiopia)",
-            "country_english": "Ethiopia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "am-ET-AmehaNeural": {
-        "key": "am-ET-AmehaNeural",
-        "name": "\u12a0\u121d\u1200",
-        "language": {
-            "code": "am-ET",
-            "family": "am",
-            "region": "ET",
-            "name_native": "Amharic (Ethiopia)",
-            "name_english": "Amharic (Ethiopia)",
-            "country_english": "Ethiopia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-AE-FatimaNeural": {
-        "key": "ar-AE-FatimaNeural",
-        "name": "\u0641\u0627\u0637\u0645\u0629",
-        "language": {
-            "code": "ar-AE",
-            "family": "ar",
-            "region": "AE",
-            "name_native": "Arabic (United Arab Emirates)",
-            "name_english": "Arabic (United Arab Emirates)",
-            "country_english": "United Arab Emirates"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-AE-HamdanNeural": {
-        "key": "ar-AE-HamdanNeural",
-        "name": "\u062d\u0645\u062f\u0627\u0646",
-        "language": {
-            "code": "ar-AE",
-            "family": "ar",
-            "region": "AE",
-            "name_native": "Arabic (United Arab Emirates)",
-            "name_english": "Arabic (United Arab Emirates)",
-            "country_english": "United Arab Emirates"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-BH-LailaNeural": {
-        "key": "ar-BH-LailaNeural",
-        "name": "\u0644\u064a\u0644\u0649",
-        "language": {
-            "code": "ar-BH",
-            "family": "ar",
-            "region": "BH",
-            "name_native": "Arabic (Bahrain)",
-            "name_english": "Arabic (Bahrain)",
-            "country_english": "Bahrain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-BH-AliNeural": {
-        "key": "ar-BH-AliNeural",
-        "name": "\u0639\u0644\u064a",
-        "language": {
-            "code": "ar-BH",
-            "family": "ar",
-            "region": "BH",
-            "name_native": "Arabic (Bahrain)",
-            "name_english": "Arabic (Bahrain)",
-            "country_english": "Bahrain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-DZ-AminaNeural": {
-        "key": "ar-DZ-AminaNeural",
-        "name": "\u0623\u0645\u064a\u0646\u0629",
-        "language": {
-            "code": "ar-DZ",
-            "family": "ar",
-            "region": "DZ",
-            "name_native": "Arabic (Algeria)",
-            "name_english": "Arabic (Algeria)",
-            "country_english": "Algeria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-DZ-IsmaelNeural": {
-        "key": "ar-DZ-IsmaelNeural",
-        "name": "\u0625\u0633\u0645\u0627\u0639\u064a\u0644",
-        "language": {
-            "code": "ar-DZ",
-            "family": "ar",
-            "region": "DZ",
-            "name_native": "Arabic (Algeria)",
-            "name_english": "Arabic (Algeria)",
-            "country_english": "Algeria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-EG-SalmaNeural": {
-        "key": "ar-EG-SalmaNeural",
-        "name": "\u0633\u0644\u0645\u0649",
-        "language": {
-            "code": "ar-EG",
-            "family": "ar",
-            "region": "EG",
-            "name_native": "Arabic (Egypt)",
-            "name_english": "Arabic (Egypt)",
-            "country_english": "Egypt"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-EG-ShakirNeural": {
-        "key": "ar-EG-ShakirNeural",
-        "name": "\u0634\u0627\u0643\u0631",
-        "language": {
-            "code": "ar-EG",
-            "family": "ar",
-            "region": "EG",
-            "name_native": "Arabic (Egypt)",
-            "name_english": "Arabic (Egypt)",
-            "country_english": "Egypt"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-IQ-RanaNeural": {
-        "key": "ar-IQ-RanaNeural",
-        "name": "\u0631\u0646\u0627",
-        "language": {
-            "code": "ar-IQ",
-            "family": "ar",
-            "region": "IQ",
-            "name_native": "Arabic (Iraq)",
-            "name_english": "Arabic (Iraq)",
-            "country_english": "Iraq"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-IQ-BasselNeural": {
-        "key": "ar-IQ-BasselNeural",
-        "name": "\u0628\u0627\u0633\u0644",
-        "language": {
-            "code": "ar-IQ",
-            "family": "ar",
-            "region": "IQ",
-            "name_native": "Arabic (Iraq)",
-            "name_english": "Arabic (Iraq)",
-            "country_english": "Iraq"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-JO-SanaNeural": {
-        "key": "ar-JO-SanaNeural",
-        "name": "\u0633\u0646\u0627\u0621",
-        "language": {
-            "code": "ar-JO",
-            "family": "ar",
-            "region": "JO",
-            "name_native": "Arabic (Jordan)",
-            "name_english": "Arabic (Jordan)",
-            "country_english": "Jordan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-JO-TaimNeural": {
-        "key": "ar-JO-TaimNeural",
-        "name": "\u062a\u064a\u0645",
-        "language": {
-            "code": "ar-JO",
-            "family": "ar",
-            "region": "JO",
-            "name_native": "Arabic (Jordan)",
-            "name_english": "Arabic (Jordan)",
-            "country_english": "Jordan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-KW-NouraNeural": {
-        "key": "ar-KW-NouraNeural",
-        "name": "\u0646\u0648\u0631\u0627",
-        "language": {
-            "code": "ar-KW",
-            "family": "ar",
-            "region": "KW",
-            "name_native": "Arabic (Kuwait)",
-            "name_english": "Arabic (Kuwait)",
-            "country_english": "Kuwait"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-KW-FahedNeural": {
-        "key": "ar-KW-FahedNeural",
-        "name": "\u0641\u0647\u062f",
-        "language": {
-            "code": "ar-KW",
-            "family": "ar",
-            "region": "KW",
-            "name_native": "Arabic (Kuwait)",
-            "name_english": "Arabic (Kuwait)",
-            "country_english": "Kuwait"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-LB-LaylaNeural": {
-        "key": "ar-LB-LaylaNeural",
-        "name": "\u0644\u064a\u0644\u0649",
-        "language": {
-            "code": "ar-LB",
-            "family": "ar",
-            "region": "LB",
-            "name_native": "Arabic (Lebanon)",
-            "name_english": "Arabic (Lebanon)",
-            "country_english": "Lebanon"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-LB-RamiNeural": {
-        "key": "ar-LB-RamiNeural",
-        "name": "\u0631\u0627\u0645\u064a",
-        "language": {
-            "code": "ar-LB",
-            "family": "ar",
-            "region": "LB",
-            "name_native": "Arabic (Lebanon)",
-            "name_english": "Arabic (Lebanon)",
-            "country_english": "Lebanon"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-LY-ImanNeural": {
-        "key": "ar-LY-ImanNeural",
-        "name": "\u0625\u064a\u0645\u0627\u0646",
-        "language": {
-            "code": "ar-LY",
-            "family": "ar",
-            "region": "LY",
-            "name_native": "Arabic (Libya)",
-            "name_english": "Arabic (Libya)",
-            "country_english": "Libya"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-LY-OmarNeural": {
-        "key": "ar-LY-OmarNeural",
-        "name": "\u0623\u062d\u0645\u062f",
-        "language": {
-            "code": "ar-LY",
-            "family": "ar",
-            "region": "LY",
-            "name_native": "Arabic (Libya)",
-            "name_english": "Arabic (Libya)",
-            "country_english": "Libya"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-MA-MounaNeural": {
-        "key": "ar-MA-MounaNeural",
-        "name": "\u0645\u0646\u0649",
-        "language": {
-            "code": "ar-MA",
-            "family": "ar",
-            "region": "MA",
-            "name_native": "Arabic (Morocco)",
-            "name_english": "Arabic (Morocco)",
-            "country_english": "Morocco"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-MA-JamalNeural": {
-        "key": "ar-MA-JamalNeural",
-        "name": "\u062c\u0645\u0627\u0644",
-        "language": {
-            "code": "ar-MA",
-            "family": "ar",
-            "region": "MA",
-            "name_native": "Arabic (Morocco)",
-            "name_english": "Arabic (Morocco)",
-            "country_english": "Morocco"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-OM-AyshaNeural": {
-        "key": "ar-OM-AyshaNeural",
-        "name": "\u0639\u0627\u0626\u0634\u0629",
-        "language": {
-            "code": "ar-OM",
-            "family": "ar",
-            "region": "OM",
-            "name_native": "Arabic (Oman)",
-            "name_english": "Arabic (Oman)",
-            "country_english": "Oman"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-OM-AbdullahNeural": {
-        "key": "ar-OM-AbdullahNeural",
-        "name": "\u0639\u0628\u062f\u0627\u0644\u0644\u0647",
-        "language": {
-            "code": "ar-OM",
-            "family": "ar",
-            "region": "OM",
-            "name_native": "Arabic (Oman)",
-            "name_english": "Arabic (Oman)",
-            "country_english": "Oman"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-QA-AmalNeural": {
-        "key": "ar-QA-AmalNeural",
-        "name": "\u0623\u0645\u0644",
-        "language": {
-            "code": "ar-QA",
-            "family": "ar",
-            "region": "QA",
-            "name_native": "Arabic (Qatar)",
-            "name_english": "Arabic (Qatar)",
-            "country_english": "Qatar"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-QA-MoazNeural": {
-        "key": "ar-QA-MoazNeural",
-        "name": "\u0645\u0639\u0627\u0630",
-        "language": {
-            "code": "ar-QA",
-            "family": "ar",
-            "region": "QA",
-            "name_native": "Arabic (Qatar)",
-            "name_english": "Arabic (Qatar)",
-            "country_english": "Qatar"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-SA-ZariyahNeural": {
-        "key": "ar-SA-ZariyahNeural",
-        "name": "\u0632\u0627\u0631\u064a\u0629",
-        "language": {
-            "code": "ar-SA",
-            "family": "ar",
-            "region": "SA",
-            "name_native": "Arabic (Saudi Arabia)",
-            "name_english": "Arabic (Saudi Arabia)",
-            "country_english": "Saudi Arabia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-SA-HamedNeural": {
-        "key": "ar-SA-HamedNeural",
-        "name": "\u062d\u0627\u0645\u062f",
-        "language": {
-            "code": "ar-SA",
-            "family": "ar",
-            "region": "SA",
-            "name_native": "Arabic (Saudi Arabia)",
-            "name_english": "Arabic (Saudi Arabia)",
-            "country_english": "Saudi Arabia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-SY-AmanyNeural": {
-        "key": "ar-SY-AmanyNeural",
-        "name": "\u0623\u0645\u0627\u0646\u064a",
-        "language": {
-            "code": "ar-SY",
-            "family": "ar",
-            "region": "SY",
-            "name_native": "Arabic (Syria)",
-            "name_english": "Arabic (Syria)",
-            "country_english": "Syrian Arab Republic"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-SY-LaithNeural": {
-        "key": "ar-SY-LaithNeural",
-        "name": "\u0644\u064a\u062b",
-        "language": {
-            "code": "ar-SY",
-            "family": "ar",
-            "region": "SY",
-            "name_native": "Arabic (Syria)",
-            "name_english": "Arabic (Syria)",
-            "country_english": "Syrian Arab Republic"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-TN-ReemNeural": {
-        "key": "ar-TN-ReemNeural",
-        "name": "\u0631\u064a\u0645",
-        "language": {
-            "code": "ar-TN",
-            "family": "ar",
-            "region": "TN",
-            "name_native": "Arabic (Tunisia)",
-            "name_english": "Arabic (Tunisia)",
-            "country_english": "Tunisia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-TN-HediNeural": {
-        "key": "ar-TN-HediNeural",
-        "name": "\u0647\u0627\u062f\u064a",
-        "language": {
-            "code": "ar-TN",
-            "family": "ar",
-            "region": "TN",
-            "name_native": "Arabic (Tunisia)",
-            "name_english": "Arabic (Tunisia)",
-            "country_english": "Tunisia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-YE-MaryamNeural": {
-        "key": "ar-YE-MaryamNeural",
-        "name": "\u0645\u0631\u064a\u0645",
-        "language": {
-            "code": "ar-YE",
-            "family": "ar",
-            "region": "YE",
-            "name_native": "Arabic (Yemen)",
-            "name_english": "Arabic (Yemen)",
-            "country_english": "Yemen"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ar-YE-SalehNeural": {
-        "key": "ar-YE-SalehNeural",
-        "name": "\u0635\u0627\u0644\u062d",
-        "language": {
-            "code": "ar-YE",
-            "family": "ar",
-            "region": "YE",
-            "name_native": "Arabic (Yemen)",
-            "name_english": "Arabic (Yemen)",
-            "country_english": "Yemen"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "az-AZ-BanuNeural": {
-        "key": "az-AZ-BanuNeural",
-        "name": "Banu",
-        "language": {
-            "code": "az-AZ",
-            "family": "az",
-            "region": "AZ",
-            "name_native": "Azerbaijani (Latin, Azerbaijan)",
-            "name_english": "Azerbaijani (Latin, Azerbaijan)",
-            "country_english": "Azerbaijan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "az-AZ-BabekNeural": {
-        "key": "az-AZ-BabekNeural",
-        "name": "Bab\u0259k",
-        "language": {
-            "code": "az-AZ",
-            "family": "az",
-            "region": "AZ",
-            "name_native": "Azerbaijani (Latin, Azerbaijan)",
-            "name_english": "Azerbaijani (Latin, Azerbaijan)",
-            "country_english": "Azerbaijan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bg-BG-KalinaNeural": {
-        "key": "bg-BG-KalinaNeural",
-        "name": "\u041a\u0430\u043b\u0438\u043d\u0430",
-        "language": {
-            "code": "bg-BG",
-            "family": "bg",
-            "region": "BG",
-            "name_native": "Bulgarian (Bulgaria)",
-            "name_english": "Bulgarian (Bulgaria)",
-            "country_english": "Bulgaria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bg-BG-BorislavNeural": {
-        "key": "bg-BG-BorislavNeural",
-        "name": "\u0411\u043e\u0440\u0438\u0441\u043b\u0430\u0432",
-        "language": {
-            "code": "bg-BG",
-            "family": "bg",
-            "region": "BG",
-            "name_native": "Bulgarian (Bulgaria)",
-            "name_english": "Bulgarian (Bulgaria)",
-            "country_english": "Bulgaria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bn-BD-NabanitaNeural": {
-        "key": "bn-BD-NabanitaNeural",
-        "name": "\u09a8\u09ac\u09a8\u09c0\u09a4\u09be",
-        "language": {
-            "code": "bn-BD",
-            "family": "bn",
-            "region": "BD",
-            "name_native": "Bangla (Bangladesh)",
-            "name_english": "Bangla (Bangladesh)",
-            "country_english": "Bangladesh"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bn-BD-PradeepNeural": {
-        "key": "bn-BD-PradeepNeural",
-        "name": "\u09aa\u09cd\u09b0\u09a6\u09cd\u09ac\u09c0\u09aa",
-        "language": {
-            "code": "bn-BD",
-            "family": "bn",
-            "region": "BD",
-            "name_native": "Bangla (Bangladesh)",
-            "name_english": "Bangla (Bangladesh)",
-            "country_english": "Bangladesh"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bn-IN-TanishaaNeural": {
-        "key": "bn-IN-TanishaaNeural",
-        "name": "\u09a4\u09be\u09a8\u09bf\u09b6\u09be",
-        "language": {
-            "code": "bn-IN",
-            "family": "bn",
-            "region": "IN",
-            "name_native": "Bengali (India)",
-            "name_english": "Bengali (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bn-IN-BashkarNeural": {
-        "key": "bn-IN-BashkarNeural",
-        "name": "\u09ad\u09be\u09b8\u09cd\u0995\u09b0",
-        "language": {
-            "code": "bn-IN",
-            "family": "bn",
-            "region": "IN",
-            "name_native": "Bengali (India)",
-            "name_english": "Bengali (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bs-BA-VesnaNeural": {
-        "key": "bs-BA-VesnaNeural",
-        "name": "Vesna",
-        "language": {
-            "code": "bs-BA",
-            "family": "bs",
-            "region": "BA",
-            "name_native": "Bosnian (Bosnia and Herzegovina)",
-            "name_english": "Bosnian (Bosnia and Herzegovina)",
-            "country_english": "Bosnia and Herzegovina"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "bs-BA-GoranNeural": {
-        "key": "bs-BA-GoranNeural",
-        "name": "Goran",
-        "language": {
-            "code": "bs-BA",
-            "family": "bs",
-            "region": "BA",
-            "name_native": "Bosnian (Bosnia and Herzegovina)",
-            "name_english": "Bosnian (Bosnia and Herzegovina)",
-            "country_english": "Bosnia and Herzegovina"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ca-ES-JoanaNeural": {
-        "key": "ca-ES-JoanaNeural",
-        "name": "Joana",
-        "language": {
-            "code": "ca-ES",
-            "family": "ca",
-            "region": "ES",
-            "name_native": "Catalan (Spain)",
-            "name_english": "Catalan (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ca-ES-EnricNeural": {
-        "key": "ca-ES-EnricNeural",
-        "name": "Enric",
-        "language": {
-            "code": "ca-ES",
-            "family": "ca",
-            "region": "ES",
-            "name_native": "Catalan (Spain)",
-            "name_english": "Catalan (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ca-ES-AlbaNeural": {
-        "key": "ca-ES-AlbaNeural",
-        "name": "Alba",
-        "language": {
-            "code": "ca-ES",
-            "family": "ca",
-            "region": "ES",
-            "name_native": "Catalan (Spain)",
-            "name_english": "Catalan (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "cs-CZ-VlastaNeural": {
-        "key": "cs-CZ-VlastaNeural",
-        "name": "Vlasta",
-        "language": {
-            "code": "cs-CZ",
-            "family": "cs",
-            "region": "CZ",
-            "name_native": "Czech (Czechia)",
-            "name_english": "Czech (Czechia)",
-            "country_english": "Czechia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "cs-CZ-AntoninNeural": {
-        "key": "cs-CZ-AntoninNeural",
-        "name": "Anton\u00edn",
-        "language": {
-            "code": "cs-CZ",
-            "family": "cs",
-            "region": "CZ",
-            "name_native": "Czech (Czechia)",
-            "name_english": "Czech (Czechia)",
-            "country_english": "Czechia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "cy-GB-NiaNeural": {
-        "key": "cy-GB-NiaNeural",
-        "name": "Nia",
-        "language": {
-            "code": "cy-GB",
-            "family": "cy",
-            "region": "GB",
-            "name_native": "Welsh (United Kingdom)",
-            "name_english": "Welsh (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "cy-GB-AledNeural": {
-        "key": "cy-GB-AledNeural",
-        "name": "Aled",
-        "language": {
-            "code": "cy-GB",
-            "family": "cy",
-            "region": "GB",
-            "name_native": "Welsh (United Kingdom)",
-            "name_english": "Welsh (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "da-DK-ChristelNeural": {
-        "key": "da-DK-ChristelNeural",
-        "name": "Christel",
-        "language": {
-            "code": "da-DK",
-            "family": "da",
-            "region": "DK",
-            "name_native": "Danish (Denmark)",
-            "name_english": "Danish (Denmark)",
-            "country_english": "Denmark"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "da-DK-JeppeNeural": {
-        "key": "da-DK-JeppeNeural",
-        "name": "Jeppe",
-        "language": {
-            "code": "da-DK",
-            "family": "da",
-            "region": "DK",
-            "name_native": "Danish (Denmark)",
-            "name_english": "Danish (Denmark)",
-            "country_english": "Denmark"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-AT-IngridNeural": {
-        "key": "de-AT-IngridNeural",
-        "name": "Ingrid",
-        "language": {
-            "code": "de-AT",
-            "family": "de",
-            "region": "AT",
-            "name_native": "German (Austria)",
-            "name_english": "German (Austria)",
-            "country_english": "Austria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-AT-JonasNeural": {
-        "key": "de-AT-JonasNeural",
-        "name": "Jonas",
-        "language": {
-            "code": "de-AT",
-            "family": "de",
-            "region": "AT",
-            "name_native": "German (Austria)",
-            "name_english": "German (Austria)",
-            "country_english": "Austria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-CH-LeniNeural": {
-        "key": "de-CH-LeniNeural",
-        "name": "Leni",
-        "language": {
-            "code": "de-CH",
-            "family": "de",
-            "region": "CH",
-            "name_native": "German (Switzerland)",
-            "name_english": "German (Switzerland)",
-            "country_english": "Switzerland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-CH-JanNeural": {
-        "key": "de-CH-JanNeural",
-        "name": "Jan",
-        "language": {
-            "code": "de-CH",
-            "family": "de",
-            "region": "CH",
-            "name_native": "German (Switzerland)",
-            "name_english": "German (Switzerland)",
-            "country_english": "Switzerland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-KatjaNeural": {
-        "key": "de-DE-KatjaNeural",
-        "name": "Katja",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-ConradNeural": {
-        "key": "de-DE-ConradNeural",
-        "name": "Conrad",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-AmalaNeural": {
-        "key": "de-DE-AmalaNeural",
-        "name": "Amala",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-BerndNeural": {
-        "key": "de-DE-BerndNeural",
-        "name": "Bernd",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-ChristophNeural": {
-        "key": "de-DE-ChristophNeural",
-        "name": "Christoph",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-ElkeNeural": {
-        "key": "de-DE-ElkeNeural",
-        "name": "Elke",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-GiselaNeural": {
-        "key": "de-DE-GiselaNeural",
-        "name": "Gisela",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-KasperNeural": {
-        "key": "de-DE-KasperNeural",
-        "name": "Kasper",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-KillianNeural": {
-        "key": "de-DE-KillianNeural",
-        "name": "Killian",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-KlarissaNeural": {
-        "key": "de-DE-KlarissaNeural",
-        "name": "Klarissa",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-KlausNeural": {
-        "key": "de-DE-KlausNeural",
-        "name": "Klaus",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-LouisaNeural": {
-        "key": "de-DE-LouisaNeural",
-        "name": "Louisa",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-MajaNeural": {
-        "key": "de-DE-MajaNeural",
-        "name": "Maja",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-RalfNeural": {
-        "key": "de-DE-RalfNeural",
-        "name": "Ralf",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "de-DE-TanjaNeural": {
-        "key": "de-DE-TanjaNeural",
-        "name": "Tanja",
-        "language": {
-            "code": "de-DE",
-            "family": "de",
-            "region": "DE",
-            "name_native": "German (Germany)",
-            "name_english": "German (Germany)",
-            "country_english": "Germany"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "el-GR-AthinaNeural": {
-        "key": "el-GR-AthinaNeural",
-        "name": "\u0391\u03b8\u03b7\u03bd\u03ac",
-        "language": {
-            "code": "el-GR",
-            "family": "el",
-            "region": "GR",
-            "name_native": "Greek (Greece)",
-            "name_english": "Greek (Greece)",
-            "country_english": "Greece"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "el-GR-NestorasNeural": {
-        "key": "el-GR-NestorasNeural",
-        "name": "\u039d\u03ad\u03c3\u03c4\u03bf\u03c1\u03b1\u03c2",
-        "language": {
-            "code": "el-GR",
-            "family": "el",
-            "region": "GR",
-            "name_native": "Greek (Greece)",
-            "name_english": "Greek (Greece)",
-            "country_english": "Greece"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-NatashaNeural": {
-        "key": "en-AU-NatashaNeural",
-        "name": "Natasha",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-WilliamNeural": {
-        "key": "en-AU-WilliamNeural",
-        "name": "William",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-AnnetteNeural": {
-        "key": "en-AU-AnnetteNeural",
-        "name": "Annette",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-CarlyNeural": {
-        "key": "en-AU-CarlyNeural",
-        "name": "Carly",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-DarrenNeural": {
-        "key": "en-AU-DarrenNeural",
-        "name": "Darren",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-DuncanNeural": {
-        "key": "en-AU-DuncanNeural",
-        "name": "Duncan",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-ElsieNeural": {
-        "key": "en-AU-ElsieNeural",
-        "name": "Elsie",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-FreyaNeural": {
-        "key": "en-AU-FreyaNeural",
-        "name": "Freya",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-JoanneNeural": {
-        "key": "en-AU-JoanneNeural",
-        "name": "Joanne",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-KenNeural": {
-        "key": "en-AU-KenNeural",
-        "name": "Ken",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-KimNeural": {
-        "key": "en-AU-KimNeural",
-        "name": "Kim",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-NeilNeural": {
-        "key": "en-AU-NeilNeural",
-        "name": "Neil",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-TimNeural": {
-        "key": "en-AU-TimNeural",
-        "name": "Tim",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-AU-TinaNeural": {
-        "key": "en-AU-TinaNeural",
-        "name": "Tina",
-        "language": {
-            "code": "en-AU",
-            "family": "en",
-            "region": "AU",
-            "name_native": "English (Australia)",
-            "name_english": "English (Australia)",
-            "country_english": "Australia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-CA-ClaraNeural": {
-        "key": "en-CA-ClaraNeural",
-        "name": "Clara",
-        "language": {
-            "code": "en-CA",
-            "family": "en",
-            "region": "CA",
-            "name_native": "English (Canada)",
-            "name_english": "English (Canada)",
-            "country_english": "Canada"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-CA-LiamNeural": {
-        "key": "en-CA-LiamNeural",
-        "name": "Liam",
-        "language": {
-            "code": "en-CA",
-            "family": "en",
-            "region": "CA",
-            "name_native": "English (Canada)",
-            "name_english": "English (Canada)",
-            "country_english": "Canada"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-SoniaNeural": {
-        "key": "en-GB-SoniaNeural",
-        "name": "Sonia",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-RyanNeural": {
-        "key": "en-GB-RyanNeural",
-        "name": "Ryan",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-LibbyNeural": {
-        "key": "en-GB-LibbyNeural",
-        "name": "Libby",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-AbbiNeural": {
-        "key": "en-GB-AbbiNeural",
-        "name": "Abbi",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-AlfieNeural": {
-        "key": "en-GB-AlfieNeural",
-        "name": "Alfie",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-BellaNeural": {
-        "key": "en-GB-BellaNeural",
-        "name": "Bella",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-ElliotNeural": {
-        "key": "en-GB-ElliotNeural",
-        "name": "Elliot",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-EthanNeural": {
-        "key": "en-GB-EthanNeural",
-        "name": "Ethan",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-HollieNeural": {
-        "key": "en-GB-HollieNeural",
-        "name": "Hollie",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-MaisieNeural": {
-        "key": "en-GB-MaisieNeural",
-        "name": "Maisie",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-NoahNeural": {
-        "key": "en-GB-NoahNeural",
-        "name": "Noah",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-OliverNeural": {
-        "key": "en-GB-OliverNeural",
-        "name": "Oliver",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-OliviaNeural": {
-        "key": "en-GB-OliviaNeural",
-        "name": "Olivia",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-ThomasNeural": {
-        "key": "en-GB-ThomasNeural",
-        "name": "Thomas",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-GB-MiaNeural": {
-        "key": "en-GB-MiaNeural",
-        "name": "Mia",
-        "language": {
-            "code": "en-GB",
-            "family": "en",
-            "region": "GB",
-            "name_native": "English (United Kingdom)",
-            "name_english": "English (United Kingdom)",
-            "country_english": "United Kingdom"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-HK-YanNeural": {
-        "key": "en-HK-YanNeural",
-        "name": "Yan",
-        "language": {
-            "code": "en-HK",
-            "family": "en",
-            "region": "HK",
-            "name_native": "English (Hong Kong SAR)",
-            "name_english": "English (Hong Kong SAR)",
-            "country_english": "Hong Kong"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-HK-SamNeural": {
-        "key": "en-HK-SamNeural",
-        "name": "Sam",
-        "language": {
-            "code": "en-HK",
-            "family": "en",
-            "region": "HK",
-            "name_native": "English (Hong Kong SAR)",
-            "name_english": "English (Hong Kong SAR)",
-            "country_english": "Hong Kong"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-IE-EmilyNeural": {
-        "key": "en-IE-EmilyNeural",
-        "name": "Emily",
-        "language": {
-            "code": "en-IE",
-            "family": "en",
-            "region": "IE",
-            "name_native": "English (Ireland)",
-            "name_english": "English (Ireland)",
-            "country_english": "Ireland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-IE-ConnorNeural": {
-        "key": "en-IE-ConnorNeural",
-        "name": "Connor",
-        "language": {
-            "code": "en-IE",
-            "family": "en",
-            "region": "IE",
-            "name_native": "English (Ireland)",
-            "name_english": "English (Ireland)",
-            "country_english": "Ireland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-IN-NeerjaNeural": {
-        "key": "en-IN-NeerjaNeural",
-        "name": "Neerja",
-        "language": {
-            "code": "en-IN",
-            "family": "en",
-            "region": "IN",
-            "name_native": "English (India)",
-            "name_english": "English (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-IN-PrabhatNeural": {
-        "key": "en-IN-PrabhatNeural",
-        "name": "Prabhat",
-        "language": {
-            "code": "en-IN",
-            "family": "en",
-            "region": "IN",
-            "name_native": "English (India)",
-            "name_english": "English (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-KE-AsiliaNeural": {
-        "key": "en-KE-AsiliaNeural",
-        "name": "Asilia",
-        "language": {
-            "code": "en-KE",
-            "family": "en",
-            "region": "KE",
-            "name_native": "English (Kenya)",
-            "name_english": "English (Kenya)",
-            "country_english": "Kenya"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-KE-ChilembaNeural": {
-        "key": "en-KE-ChilembaNeural",
-        "name": "Chilemba",
-        "language": {
-            "code": "en-KE",
-            "family": "en",
-            "region": "KE",
-            "name_native": "English (Kenya)",
-            "name_english": "English (Kenya)",
-            "country_english": "Kenya"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-NG-EzinneNeural": {
-        "key": "en-NG-EzinneNeural",
-        "name": "Ezinne",
-        "language": {
-            "code": "en-NG",
-            "family": "en",
-            "region": "NG",
-            "name_native": "English (Nigeria)",
-            "name_english": "English (Nigeria)",
-            "country_english": "Nigeria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-NG-AbeoNeural": {
-        "key": "en-NG-AbeoNeural",
-        "name": "Abeo",
-        "language": {
-            "code": "en-NG",
-            "family": "en",
-            "region": "NG",
-            "name_native": "English (Nigeria)",
-            "name_english": "English (Nigeria)",
-            "country_english": "Nigeria"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-NZ-MollyNeural": {
-        "key": "en-NZ-MollyNeural",
-        "name": "Molly",
-        "language": {
-            "code": "en-NZ",
-            "family": "en",
-            "region": "NZ",
-            "name_native": "English (New Zealand)",
-            "name_english": "English (New Zealand)",
-            "country_english": "New Zealand"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-NZ-MitchellNeural": {
-        "key": "en-NZ-MitchellNeural",
-        "name": "Mitchell",
-        "language": {
-            "code": "en-NZ",
-            "family": "en",
-            "region": "NZ",
-            "name_native": "English (New Zealand)",
-            "name_english": "English (New Zealand)",
-            "country_english": "New Zealand"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-PH-RosaNeural": {
-        "key": "en-PH-RosaNeural",
-        "name": "Rosa",
-        "language": {
-            "code": "en-PH",
-            "family": "en",
-            "region": "PH",
-            "name_native": "English (Philippines)",
-            "name_english": "English (Philippines)",
-            "country_english": "Philippines"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-PH-JamesNeural": {
-        "key": "en-PH-JamesNeural",
-        "name": "James",
-        "language": {
-            "code": "en-PH",
-            "family": "en",
-            "region": "PH",
-            "name_native": "English (Philippines)",
-            "name_english": "English (Philippines)",
-            "country_english": "Philippines"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-SG-LunaNeural": {
-        "key": "en-SG-LunaNeural",
-        "name": "Luna",
-        "language": {
-            "code": "en-SG",
-            "family": "en",
-            "region": "SG",
-            "name_native": "English (Singapore)",
-            "name_english": "English (Singapore)",
-            "country_english": "Singapore"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-SG-WayneNeural": {
-        "key": "en-SG-WayneNeural",
-        "name": "Wayne",
-        "language": {
-            "code": "en-SG",
-            "family": "en",
-            "region": "SG",
-            "name_native": "English (Singapore)",
-            "name_english": "English (Singapore)",
-            "country_english": "Singapore"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-TZ-ImaniNeural": {
-        "key": "en-TZ-ImaniNeural",
-        "name": "Imani",
-        "language": {
-            "code": "en-TZ",
-            "family": "en",
-            "region": "TZ",
-            "name_native": "English (Tanzania)",
-            "name_english": "English (Tanzania)",
-            "country_english": "Tanzania, United Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-TZ-ElimuNeural": {
-        "key": "en-TZ-ElimuNeural",
-        "name": "Elimu",
-        "language": {
-            "code": "en-TZ",
-            "family": "en",
-            "region": "TZ",
-            "name_native": "English (Tanzania)",
-            "name_english": "English (Tanzania)",
-            "country_english": "Tanzania, United Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-JennyMultilingualNeural": {
-        "key": "en-US-JennyMultilingualNeural",
-        "name": "Jenny Multilingual",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-JennyNeural": {
-        "key": "en-US-JennyNeural",
-        "name": "Jenny",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-GuyNeural": {
-        "key": "en-US-GuyNeural",
-        "name": "Guy",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-AriaNeural": {
-        "key": "en-US-AriaNeural",
-        "name": "Aria",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-DavisNeural": {
-        "key": "en-US-DavisNeural",
-        "name": "Davis",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-AmberNeural": {
-        "key": "en-US-AmberNeural",
-        "name": "Amber",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-AnaNeural": {
-        "key": "en-US-AnaNeural",
-        "name": "Ana",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-AshleyNeural": {
-        "key": "en-US-AshleyNeural",
-        "name": "Ashley",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-BrandonNeural": {
-        "key": "en-US-BrandonNeural",
-        "name": "Brandon",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-ChristopherNeural": {
-        "key": "en-US-ChristopherNeural",
-        "name": "Christopher",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-CoraNeural": {
-        "key": "en-US-CoraNeural",
-        "name": "Cora",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-ElizabethNeural": {
-        "key": "en-US-ElizabethNeural",
-        "name": "Elizabeth",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-EricNeural": {
-        "key": "en-US-EricNeural",
-        "name": "Eric",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-JacobNeural": {
-        "key": "en-US-JacobNeural",
-        "name": "Jacob",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-JaneNeural": {
-        "key": "en-US-JaneNeural",
-        "name": "Jane",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-JasonNeural": {
-        "key": "en-US-JasonNeural",
-        "name": "Jason",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-MichelleNeural": {
-        "key": "en-US-MichelleNeural",
-        "name": "Michelle",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-MonicaNeural": {
-        "key": "en-US-MonicaNeural",
-        "name": "Monica",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-NancyNeural": {
-        "key": "en-US-NancyNeural",
-        "name": "Nancy",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-RogerNeural": {
-        "key": "en-US-RogerNeural",
-        "name": "Roger",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-SaraNeural": {
-        "key": "en-US-SaraNeural",
-        "name": "Sara",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-SteffanNeural": {
-        "key": "en-US-SteffanNeural",
-        "name": "Steffan",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-US-TonyNeural": {
-        "key": "en-US-TonyNeural",
-        "name": "Tony",
-        "language": {
-            "code": "en-US",
-            "family": "en",
-            "region": "US",
-            "name_native": "English (United States)",
-            "name_english": "English (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-ZA-LeahNeural": {
-        "key": "en-ZA-LeahNeural",
-        "name": "Leah",
-        "language": {
-            "code": "en-ZA",
-            "family": "en",
-            "region": "ZA",
-            "name_native": "English (South Africa)",
-            "name_english": "English (South Africa)",
-            "country_english": "South Africa"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "en-ZA-LukeNeural": {
-        "key": "en-ZA-LukeNeural",
-        "name": "Luke",
-        "language": {
-            "code": "en-ZA",
-            "family": "en",
-            "region": "ZA",
-            "name_native": "English (South Africa)",
-            "name_english": "English (South Africa)",
-            "country_english": "South Africa"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-AR-ElenaNeural": {
-        "key": "es-AR-ElenaNeural",
-        "name": "Elena",
-        "language": {
-            "code": "es-AR",
-            "family": "es",
-            "region": "AR",
-            "name_native": "Spanish (Argentina)",
-            "name_english": "Spanish (Argentina)",
-            "country_english": "Argentina"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-AR-TomasNeural": {
-        "key": "es-AR-TomasNeural",
-        "name": "Tomas",
-        "language": {
-            "code": "es-AR",
-            "family": "es",
-            "region": "AR",
-            "name_native": "Spanish (Argentina)",
-            "name_english": "Spanish (Argentina)",
-            "country_english": "Argentina"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-BO-SofiaNeural": {
-        "key": "es-BO-SofiaNeural",
-        "name": "Sofia",
-        "language": {
-            "code": "es-BO",
-            "family": "es",
-            "region": "BO",
-            "name_native": "Spanish (Bolivia)",
-            "name_english": "Spanish (Bolivia)",
-            "country_english": "Bolivia, Plurinational State of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-BO-MarceloNeural": {
-        "key": "es-BO-MarceloNeural",
-        "name": "Marcelo",
-        "language": {
-            "code": "es-BO",
-            "family": "es",
-            "region": "BO",
-            "name_native": "Spanish (Bolivia)",
-            "name_english": "Spanish (Bolivia)",
-            "country_english": "Bolivia, Plurinational State of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CL-CatalinaNeural": {
-        "key": "es-CL-CatalinaNeural",
-        "name": "Catalina",
-        "language": {
-            "code": "es-CL",
-            "family": "es",
-            "region": "CL",
-            "name_native": "Spanish (Chile)",
-            "name_english": "Spanish (Chile)",
-            "country_english": "Chile"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CL-LorenzoNeural": {
-        "key": "es-CL-LorenzoNeural",
-        "name": "Lorenzo",
-        "language": {
-            "code": "es-CL",
-            "family": "es",
-            "region": "CL",
-            "name_native": "Spanish (Chile)",
-            "name_english": "Spanish (Chile)",
-            "country_english": "Chile"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CO-SalomeNeural": {
-        "key": "es-CO-SalomeNeural",
-        "name": "Salome",
-        "language": {
-            "code": "es-CO",
-            "family": "es",
-            "region": "CO",
-            "name_native": "Spanish (Colombia)",
-            "name_english": "Spanish (Colombia)",
-            "country_english": "Colombia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CO-GonzaloNeural": {
-        "key": "es-CO-GonzaloNeural",
-        "name": "Gonzalo",
-        "language": {
-            "code": "es-CO",
-            "family": "es",
-            "region": "CO",
-            "name_native": "Spanish (Colombia)",
-            "name_english": "Spanish (Colombia)",
-            "country_english": "Colombia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CR-MariaNeural": {
-        "key": "es-CR-MariaNeural",
-        "name": "Mar\u00eda",
-        "language": {
-            "code": "es-CR",
-            "family": "es",
-            "region": "CR",
-            "name_native": "Spanish (Costa Rica)",
-            "name_english": "Spanish (Costa Rica)",
-            "country_english": "Costa Rica"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CR-JuanNeural": {
-        "key": "es-CR-JuanNeural",
-        "name": "Juan",
-        "language": {
-            "code": "es-CR",
-            "family": "es",
-            "region": "CR",
-            "name_native": "Spanish (Costa Rica)",
-            "name_english": "Spanish (Costa Rica)",
-            "country_english": "Costa Rica"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CU-BelkysNeural": {
-        "key": "es-CU-BelkysNeural",
-        "name": "Belkys",
-        "language": {
-            "code": "es-CU",
-            "family": "es",
-            "region": "CU",
-            "name_native": "Spanish (Cuba)",
-            "name_english": "Spanish (Cuba)",
-            "country_english": "Cuba"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-CU-ManuelNeural": {
-        "key": "es-CU-ManuelNeural",
-        "name": "Manuel",
-        "language": {
-            "code": "es-CU",
-            "family": "es",
-            "region": "CU",
-            "name_native": "Spanish (Cuba)",
-            "name_english": "Spanish (Cuba)",
-            "country_english": "Cuba"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-DO-RamonaNeural": {
-        "key": "es-DO-RamonaNeural",
-        "name": "Ramona",
-        "language": {
-            "code": "es-DO",
-            "family": "es",
-            "region": "DO",
-            "name_native": "Spanish (Dominican Republic)",
-            "name_english": "Spanish (Dominican Republic)",
-            "country_english": "Dominican Republic"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-DO-EmilioNeural": {
-        "key": "es-DO-EmilioNeural",
-        "name": "Emilio",
-        "language": {
-            "code": "es-DO",
-            "family": "es",
-            "region": "DO",
-            "name_native": "Spanish (Dominican Republic)",
-            "name_english": "Spanish (Dominican Republic)",
-            "country_english": "Dominican Republic"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-EC-AndreaNeural": {
-        "key": "es-EC-AndreaNeural",
-        "name": "Andrea",
-        "language": {
-            "code": "es-EC",
-            "family": "es",
-            "region": "EC",
-            "name_native": "Spanish (Ecuador)",
-            "name_english": "Spanish (Ecuador)",
-            "country_english": "Ecuador"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-EC-LuisNeural": {
-        "key": "es-EC-LuisNeural",
-        "name": "Luis",
-        "language": {
-            "code": "es-EC",
-            "family": "es",
-            "region": "EC",
-            "name_native": "Spanish (Ecuador)",
-            "name_english": "Spanish (Ecuador)",
-            "country_english": "Ecuador"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-ElviraNeural": {
-        "key": "es-ES-ElviraNeural",
-        "name": "Elvira",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-AlvaroNeural": {
-        "key": "es-ES-AlvaroNeural",
-        "name": "\u00c1lvaro",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-AbrilNeural": {
-        "key": "es-ES-AbrilNeural",
-        "name": "Abril",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-ArnauNeural": {
-        "key": "es-ES-ArnauNeural",
-        "name": "Arnau",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-DarioNeural": {
-        "key": "es-ES-DarioNeural",
-        "name": "Dario",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-EliasNeural": {
-        "key": "es-ES-EliasNeural",
-        "name": "Elias",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-EstrellaNeural": {
-        "key": "es-ES-EstrellaNeural",
-        "name": "Estrella",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-IreneNeural": {
-        "key": "es-ES-IreneNeural",
-        "name": "Irene",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-LaiaNeural": {
-        "key": "es-ES-LaiaNeural",
-        "name": "Laia",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-LiaNeural": {
-        "key": "es-ES-LiaNeural",
-        "name": "Lia",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-NilNeural": {
-        "key": "es-ES-NilNeural",
-        "name": "Nil",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-SaulNeural": {
-        "key": "es-ES-SaulNeural",
-        "name": "Saul",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-TeoNeural": {
-        "key": "es-ES-TeoNeural",
-        "name": "Teo",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-TrianaNeural": {
-        "key": "es-ES-TrianaNeural",
-        "name": "Triana",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-ES-VeraNeural": {
-        "key": "es-ES-VeraNeural",
-        "name": "Vera",
-        "language": {
-            "code": "es-ES",
-            "family": "es",
-            "region": "ES",
-            "name_native": "Spanish (Spain)",
-            "name_english": "Spanish (Spain)",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-GQ-TeresaNeural": {
-        "key": "es-GQ-TeresaNeural",
-        "name": "Teresa",
-        "language": {
-            "code": "es-GQ",
-            "family": "es",
-            "region": "GQ",
-            "name_native": "Spanish (Equatorial Guinea)",
-            "name_english": "Spanish (Equatorial Guinea)",
-            "country_english": "Equatorial Guinea"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-GQ-JavierNeural": {
-        "key": "es-GQ-JavierNeural",
-        "name": "Javier",
-        "language": {
-            "code": "es-GQ",
-            "family": "es",
-            "region": "GQ",
-            "name_native": "Spanish (Equatorial Guinea)",
-            "name_english": "Spanish (Equatorial Guinea)",
-            "country_english": "Equatorial Guinea"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-GT-MartaNeural": {
-        "key": "es-GT-MartaNeural",
-        "name": "Marta",
-        "language": {
-            "code": "es-GT",
-            "family": "es",
-            "region": "GT",
-            "name_native": "Spanish (Guatemala)",
-            "name_english": "Spanish (Guatemala)",
-            "country_english": "Guatemala"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-GT-AndresNeural": {
-        "key": "es-GT-AndresNeural",
-        "name": "Andr\u00e9s",
-        "language": {
-            "code": "es-GT",
-            "family": "es",
-            "region": "GT",
-            "name_native": "Spanish (Guatemala)",
-            "name_english": "Spanish (Guatemala)",
-            "country_english": "Guatemala"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-HN-KarlaNeural": {
-        "key": "es-HN-KarlaNeural",
-        "name": "Karla",
-        "language": {
-            "code": "es-HN",
-            "family": "es",
-            "region": "HN",
-            "name_native": "Spanish (Honduras)",
-            "name_english": "Spanish (Honduras)",
-            "country_english": "Honduras"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-HN-CarlosNeural": {
-        "key": "es-HN-CarlosNeural",
-        "name": "Carlos",
-        "language": {
-            "code": "es-HN",
-            "family": "es",
-            "region": "HN",
-            "name_native": "Spanish (Honduras)",
-            "name_english": "Spanish (Honduras)",
-            "country_english": "Honduras"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-DaliaNeural": {
-        "key": "es-MX-DaliaNeural",
-        "name": "Dalia",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-JorgeNeural": {
-        "key": "es-MX-JorgeNeural",
-        "name": "Jorge",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-BeatrizNeural": {
-        "key": "es-MX-BeatrizNeural",
-        "name": "Beatriz",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-CandelaNeural": {
-        "key": "es-MX-CandelaNeural",
-        "name": "Candela",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-CarlotaNeural": {
-        "key": "es-MX-CarlotaNeural",
-        "name": "Carlota",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-CecilioNeural": {
-        "key": "es-MX-CecilioNeural",
-        "name": "Cecilio",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-GerardoNeural": {
-        "key": "es-MX-GerardoNeural",
-        "name": "Gerardo",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-LarissaNeural": {
-        "key": "es-MX-LarissaNeural",
-        "name": "Larissa",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-LibertoNeural": {
-        "key": "es-MX-LibertoNeural",
-        "name": "Liberto",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-LucianoNeural": {
-        "key": "es-MX-LucianoNeural",
-        "name": "Luciano",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-MarinaNeural": {
-        "key": "es-MX-MarinaNeural",
-        "name": "Marina",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-NuriaNeural": {
-        "key": "es-MX-NuriaNeural",
-        "name": "Nuria",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-PelayoNeural": {
-        "key": "es-MX-PelayoNeural",
-        "name": "Pelayo",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-RenataNeural": {
-        "key": "es-MX-RenataNeural",
-        "name": "Renata",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-MX-YagoNeural": {
-        "key": "es-MX-YagoNeural",
-        "name": "Yago",
-        "language": {
-            "code": "es-MX",
-            "family": "es",
-            "region": "MX",
-            "name_native": "Spanish (Mexico)",
-            "name_english": "Spanish (Mexico)",
-            "country_english": "Mexico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-NI-YolandaNeural": {
-        "key": "es-NI-YolandaNeural",
-        "name": "Yolanda",
-        "language": {
-            "code": "es-NI",
-            "family": "es",
-            "region": "NI",
-            "name_native": "Spanish (Nicaragua)",
-            "name_english": "Spanish (Nicaragua)",
-            "country_english": "Nicaragua"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-NI-FedericoNeural": {
-        "key": "es-NI-FedericoNeural",
-        "name": "Federico",
-        "language": {
-            "code": "es-NI",
-            "family": "es",
-            "region": "NI",
-            "name_native": "Spanish (Nicaragua)",
-            "name_english": "Spanish (Nicaragua)",
-            "country_english": "Nicaragua"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PA-MargaritaNeural": {
-        "key": "es-PA-MargaritaNeural",
-        "name": "Margarita",
-        "language": {
-            "code": "es-PA",
-            "family": "es",
-            "region": "PA",
-            "name_native": "Spanish (Panama)",
-            "name_english": "Spanish (Panama)",
-            "country_english": "Panama"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PA-RobertoNeural": {
-        "key": "es-PA-RobertoNeural",
-        "name": "Roberto",
-        "language": {
-            "code": "es-PA",
-            "family": "es",
-            "region": "PA",
-            "name_native": "Spanish (Panama)",
-            "name_english": "Spanish (Panama)",
-            "country_english": "Panama"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PE-CamilaNeural": {
-        "key": "es-PE-CamilaNeural",
-        "name": "Camila",
-        "language": {
-            "code": "es-PE",
-            "family": "es",
-            "region": "PE",
-            "name_native": "Spanish (Peru)",
-            "name_english": "Spanish (Peru)",
-            "country_english": "Peru"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PE-AlexNeural": {
-        "key": "es-PE-AlexNeural",
-        "name": "Alex",
-        "language": {
-            "code": "es-PE",
-            "family": "es",
-            "region": "PE",
-            "name_native": "Spanish (Peru)",
-            "name_english": "Spanish (Peru)",
-            "country_english": "Peru"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PR-KarinaNeural": {
-        "key": "es-PR-KarinaNeural",
-        "name": "Karina",
-        "language": {
-            "code": "es-PR",
-            "family": "es",
-            "region": "PR",
-            "name_native": "Spanish (Puerto Rico)",
-            "name_english": "Spanish (Puerto Rico)",
-            "country_english": "Puerto Rico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PR-VictorNeural": {
-        "key": "es-PR-VictorNeural",
-        "name": "V\u00edctor",
-        "language": {
-            "code": "es-PR",
-            "family": "es",
-            "region": "PR",
-            "name_native": "Spanish (Puerto Rico)",
-            "name_english": "Spanish (Puerto Rico)",
-            "country_english": "Puerto Rico"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PY-TaniaNeural": {
-        "key": "es-PY-TaniaNeural",
-        "name": "Tania",
-        "language": {
-            "code": "es-PY",
-            "family": "es",
-            "region": "PY",
-            "name_native": "Spanish (Paraguay)",
-            "name_english": "Spanish (Paraguay)",
-            "country_english": "Paraguay"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-PY-MarioNeural": {
-        "key": "es-PY-MarioNeural",
-        "name": "Mario",
-        "language": {
-            "code": "es-PY",
-            "family": "es",
-            "region": "PY",
-            "name_native": "Spanish (Paraguay)",
-            "name_english": "Spanish (Paraguay)",
-            "country_english": "Paraguay"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-SV-LorenaNeural": {
-        "key": "es-SV-LorenaNeural",
-        "name": "Lorena",
-        "language": {
-            "code": "es-SV",
-            "family": "es",
-            "region": "SV",
-            "name_native": "Spanish (El Salvador)",
-            "name_english": "Spanish (El Salvador)",
-            "country_english": "El Salvador"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-SV-RodrigoNeural": {
-        "key": "es-SV-RodrigoNeural",
-        "name": "Rodrigo",
-        "language": {
-            "code": "es-SV",
-            "family": "es",
-            "region": "SV",
-            "name_native": "Spanish (El Salvador)",
-            "name_english": "Spanish (El Salvador)",
-            "country_english": "El Salvador"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-US-PalomaNeural": {
-        "key": "es-US-PalomaNeural",
-        "name": "Paloma",
-        "language": {
-            "code": "es-US",
-            "family": "es",
-            "region": "US",
-            "name_native": "Spanish (United States)",
-            "name_english": "Spanish (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-US-AlonsoNeural": {
-        "key": "es-US-AlonsoNeural",
-        "name": "Alonso",
-        "language": {
-            "code": "es-US",
-            "family": "es",
-            "region": "US",
-            "name_native": "Spanish (United States)",
-            "name_english": "Spanish (United States)",
-            "country_english": "United States"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-UY-ValentinaNeural": {
-        "key": "es-UY-ValentinaNeural",
-        "name": "Valentina",
-        "language": {
-            "code": "es-UY",
-            "family": "es",
-            "region": "UY",
-            "name_native": "Spanish (Uruguay)",
-            "name_english": "Spanish (Uruguay)",
-            "country_english": "Uruguay"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-UY-MateoNeural": {
-        "key": "es-UY-MateoNeural",
-        "name": "Mateo",
-        "language": {
-            "code": "es-UY",
-            "family": "es",
-            "region": "UY",
-            "name_native": "Spanish (Uruguay)",
-            "name_english": "Spanish (Uruguay)",
-            "country_english": "Uruguay"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-VE-PaolaNeural": {
-        "key": "es-VE-PaolaNeural",
-        "name": "Paola",
-        "language": {
-            "code": "es-VE",
-            "family": "es",
-            "region": "VE",
-            "name_native": "Spanish (Venezuela)",
-            "name_english": "Spanish (Venezuela)",
-            "country_english": "Venezuela, Bolivarian Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "es-VE-SebastianNeural": {
-        "key": "es-VE-SebastianNeural",
-        "name": "Sebasti\u00e1n",
-        "language": {
-            "code": "es-VE",
-            "family": "es",
-            "region": "VE",
-            "name_native": "Spanish (Venezuela)",
-            "name_english": "Spanish (Venezuela)",
-            "country_english": "Venezuela, Bolivarian Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "et-EE-AnuNeural": {
-        "key": "et-EE-AnuNeural",
-        "name": "Anu",
-        "language": {
-            "code": "et-EE",
-            "family": "et",
-            "region": "EE",
-            "name_native": "Estonian (Estonia)",
-            "name_english": "Estonian (Estonia)",
-            "country_english": "Estonia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "et-EE-KertNeural": {
-        "key": "et-EE-KertNeural",
-        "name": "Kert",
-        "language": {
-            "code": "et-EE",
-            "family": "et",
-            "region": "EE",
-            "name_native": "Estonian (Estonia)",
-            "name_english": "Estonian (Estonia)",
-            "country_english": "Estonia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "eu-ES-AinhoaNeural": {
-        "key": "eu-ES-AinhoaNeural",
-        "name": "Ainhoa",
-        "language": {
-            "code": "eu-ES",
-            "family": "eu",
-            "region": "ES",
-            "name_native": "Basque",
-            "name_english": "Basque",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "eu-ES-AnderNeural": {
-        "key": "eu-ES-AnderNeural",
-        "name": "Ander",
-        "language": {
-            "code": "eu-ES",
-            "family": "eu",
-            "region": "ES",
-            "name_native": "Basque",
-            "name_english": "Basque",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fa-IR-DilaraNeural": {
-        "key": "fa-IR-DilaraNeural",
-        "name": "\u062f\u0644\u0627\u0631\u0627",
-        "language": {
-            "code": "fa-IR",
-            "family": "fa",
-            "region": "IR",
-            "name_native": "Persian (Iran)",
-            "name_english": "Persian (Iran)",
-            "country_english": "Iran, Islamic Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fa-IR-FaridNeural": {
-        "key": "fa-IR-FaridNeural",
-        "name": "\u0641\u0631\u06cc\u062f",
-        "language": {
-            "code": "fa-IR",
-            "family": "fa",
-            "region": "IR",
-            "name_native": "Persian (Iran)",
-            "name_english": "Persian (Iran)",
-            "country_english": "Iran, Islamic Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fi-FI-SelmaNeural": {
-        "key": "fi-FI-SelmaNeural",
-        "name": "Selma",
-        "language": {
-            "code": "fi-FI",
-            "family": "fi",
-            "region": "FI",
-            "name_native": "Finnish (Finland)",
-            "name_english": "Finnish (Finland)",
-            "country_english": "Finland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fi-FI-HarriNeural": {
-        "key": "fi-FI-HarriNeural",
-        "name": "Harri",
-        "language": {
-            "code": "fi-FI",
-            "family": "fi",
-            "region": "FI",
-            "name_native": "Finnish (Finland)",
-            "name_english": "Finnish (Finland)",
-            "country_english": "Finland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fi-FI-NooraNeural": {
-        "key": "fi-FI-NooraNeural",
-        "name": "Noora",
-        "language": {
-            "code": "fi-FI",
-            "family": "fi",
-            "region": "FI",
-            "name_native": "Finnish (Finland)",
-            "name_english": "Finnish (Finland)",
-            "country_english": "Finland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fil-PH-BlessicaNeural": {
-        "key": "fil-PH-BlessicaNeural",
-        "name": "Blessica",
-        "language": {
-            "code": "fil-PH",
-            "family": "fil",
-            "region": "PH",
-            "name_native": "Filipino (Philippines)",
-            "name_english": "Filipino (Philippines)",
-            "country_english": "Philippines"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fil-PH-AngeloNeural": {
-        "key": "fil-PH-AngeloNeural",
-        "name": "Angelo",
-        "language": {
-            "code": "fil-PH",
-            "family": "fil",
-            "region": "PH",
-            "name_native": "Filipino (Philippines)",
-            "name_english": "Filipino (Philippines)",
-            "country_english": "Philippines"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-BE-CharlineNeural": {
-        "key": "fr-BE-CharlineNeural",
-        "name": "Charline",
-        "language": {
-            "code": "fr-BE",
-            "family": "fr",
-            "region": "BE",
-            "name_native": "French (Belgium)",
-            "name_english": "French (Belgium)",
-            "country_english": "Belgium"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-BE-GerardNeural": {
-        "key": "fr-BE-GerardNeural",
-        "name": "Gerard",
-        "language": {
-            "code": "fr-BE",
-            "family": "fr",
-            "region": "BE",
-            "name_native": "French (Belgium)",
-            "name_english": "French (Belgium)",
-            "country_english": "Belgium"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-CA-SylvieNeural": {
-        "key": "fr-CA-SylvieNeural",
-        "name": "Sylvie",
-        "language": {
-            "code": "fr-CA",
-            "family": "fr",
-            "region": "CA",
-            "name_native": "French (Canada)",
-            "name_english": "French (Canada)",
-            "country_english": "Canada"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-CA-JeanNeural": {
-        "key": "fr-CA-JeanNeural",
-        "name": "Jean",
-        "language": {
-            "code": "fr-CA",
-            "family": "fr",
-            "region": "CA",
-            "name_native": "French (Canada)",
-            "name_english": "French (Canada)",
-            "country_english": "Canada"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-CA-AntoineNeural": {
-        "key": "fr-CA-AntoineNeural",
-        "name": "Antoine",
-        "language": {
-            "code": "fr-CA",
-            "family": "fr",
-            "region": "CA",
-            "name_native": "French (Canada)",
-            "name_english": "French (Canada)",
-            "country_english": "Canada"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-CH-ArianeNeural": {
-        "key": "fr-CH-ArianeNeural",
-        "name": "Ariane",
-        "language": {
-            "code": "fr-CH",
-            "family": "fr",
-            "region": "CH",
-            "name_native": "French (Switzerland)",
-            "name_english": "French (Switzerland)",
-            "country_english": "Switzerland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-CH-FabriceNeural": {
-        "key": "fr-CH-FabriceNeural",
-        "name": "Fabrice",
-        "language": {
-            "code": "fr-CH",
-            "family": "fr",
-            "region": "CH",
-            "name_native": "French (Switzerland)",
-            "name_english": "French (Switzerland)",
-            "country_english": "Switzerland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-DeniseNeural": {
-        "key": "fr-FR-DeniseNeural",
-        "name": "Denise",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-HenriNeural": {
-        "key": "fr-FR-HenriNeural",
-        "name": "Henri",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-AlainNeural": {
-        "key": "fr-FR-AlainNeural",
-        "name": "Alain",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-BrigitteNeural": {
-        "key": "fr-FR-BrigitteNeural",
-        "name": "Brigitte",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-CelesteNeural": {
-        "key": "fr-FR-CelesteNeural",
-        "name": "Celeste",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-ClaudeNeural": {
-        "key": "fr-FR-ClaudeNeural",
-        "name": "Claude",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-CoralieNeural": {
-        "key": "fr-FR-CoralieNeural",
-        "name": "Coralie",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-EloiseNeural": {
-        "key": "fr-FR-EloiseNeural",
-        "name": "Eloise",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-JacquelineNeural": {
-        "key": "fr-FR-JacquelineNeural",
-        "name": "Jacqueline",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-JeromeNeural": {
-        "key": "fr-FR-JeromeNeural",
-        "name": "Jerome",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-JosephineNeural": {
-        "key": "fr-FR-JosephineNeural",
-        "name": "Josephine",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-MauriceNeural": {
-        "key": "fr-FR-MauriceNeural",
-        "name": "Maurice",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-YvesNeural": {
-        "key": "fr-FR-YvesNeural",
-        "name": "Yves",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "fr-FR-YvetteNeural": {
-        "key": "fr-FR-YvetteNeural",
-        "name": "Yvette",
-        "language": {
-            "code": "fr-FR",
-            "family": "fr",
-            "region": "FR",
-            "name_native": "French (France)",
-            "name_english": "French (France)",
-            "country_english": "France"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ga-IE-OrlaNeural": {
-        "key": "ga-IE-OrlaNeural",
-        "name": "Orla",
-        "language": {
-            "code": "ga-IE",
-            "family": "ga",
-            "region": "IE",
-            "name_native": "Irish (Ireland)",
-            "name_english": "Irish (Ireland)",
-            "country_english": "Ireland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ga-IE-ColmNeural": {
-        "key": "ga-IE-ColmNeural",
-        "name": "Colm",
-        "language": {
-            "code": "ga-IE",
-            "family": "ga",
-            "region": "IE",
-            "name_native": "Irish (Ireland)",
-            "name_english": "Irish (Ireland)",
-            "country_english": "Ireland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "gl-ES-SabelaNeural": {
-        "key": "gl-ES-SabelaNeural",
-        "name": "Sabela",
-        "language": {
-            "code": "gl-ES",
-            "family": "gl",
-            "region": "ES",
-            "name_native": "Galician",
-            "name_english": "Galician",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "gl-ES-RoiNeural": {
-        "key": "gl-ES-RoiNeural",
-        "name": "Roi",
-        "language": {
-            "code": "gl-ES",
-            "family": "gl",
-            "region": "ES",
-            "name_native": "Galician",
-            "name_english": "Galician",
-            "country_english": "Spain"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "gu-IN-DhwaniNeural": {
-        "key": "gu-IN-DhwaniNeural",
-        "name": "\u0aa7\u0acd\u0ab5\u0aa8\u0ac0",
-        "language": {
-            "code": "gu-IN",
-            "family": "gu",
-            "region": "IN",
-            "name_native": "Gujarati (India)",
-            "name_english": "Gujarati (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "gu-IN-NiranjanNeural": {
-        "key": "gu-IN-NiranjanNeural",
-        "name": "\u0aa8\u0abf\u0ab0\u0a82\u0a9c\u0aa8",
-        "language": {
-            "code": "gu-IN",
-            "family": "gu",
-            "region": "IN",
-            "name_native": "Gujarati (India)",
-            "name_english": "Gujarati (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "he-IL-HilaNeural": {
-        "key": "he-IL-HilaNeural",
-        "name": "\u05d4\u05d9\u05dc\u05d4",
-        "language": {
-            "code": "he-IL",
-            "family": "he",
-            "region": "IL",
-            "name_native": "Hebrew (Israel)",
-            "name_english": "Hebrew (Israel)",
-            "country_english": "Israel"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "he-IL-AvriNeural": {
-        "key": "he-IL-AvriNeural",
-        "name": "\u05d0\u05d1\u05e8\u05d9",
-        "language": {
-            "code": "he-IL",
-            "family": "he",
-            "region": "IL",
-            "name_native": "Hebrew (Israel)",
-            "name_english": "Hebrew (Israel)",
-            "country_english": "Israel"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hi-IN-SwaraNeural": {
-        "key": "hi-IN-SwaraNeural",
-        "name": "\u0938\u094d\u0935\u0930\u093e",
-        "language": {
-            "code": "hi-IN",
-            "family": "hi",
-            "region": "IN",
-            "name_native": "Hindi (India)",
-            "name_english": "Hindi (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hi-IN-MadhurNeural": {
-        "key": "hi-IN-MadhurNeural",
-        "name": "\u092e\u0927\u0941\u0930",
-        "language": {
-            "code": "hi-IN",
-            "family": "hi",
-            "region": "IN",
-            "name_native": "Hindi (India)",
-            "name_english": "Hindi (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hr-HR-GabrijelaNeural": {
-        "key": "hr-HR-GabrijelaNeural",
-        "name": "Gabrijela",
-        "language": {
-            "code": "hr-HR",
-            "family": "hr",
-            "region": "HR",
-            "name_native": "Croatian (Croatia)",
-            "name_english": "Croatian (Croatia)",
-            "country_english": "Croatia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hr-HR-SreckoNeural": {
-        "key": "hr-HR-SreckoNeural",
-        "name": "Sre\u0107ko",
-        "language": {
-            "code": "hr-HR",
-            "family": "hr",
-            "region": "HR",
-            "name_native": "Croatian (Croatia)",
-            "name_english": "Croatian (Croatia)",
-            "country_english": "Croatia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hu-HU-NoemiNeural": {
-        "key": "hu-HU-NoemiNeural",
-        "name": "No\u00e9mi",
-        "language": {
-            "code": "hu-HU",
-            "family": "hu",
-            "region": "HU",
-            "name_native": "Hungarian (Hungary)",
-            "name_english": "Hungarian (Hungary)",
-            "country_english": "Hungary"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hu-HU-TamasNeural": {
-        "key": "hu-HU-TamasNeural",
-        "name": "Tam\u00e1s",
-        "language": {
-            "code": "hu-HU",
-            "family": "hu",
-            "region": "HU",
-            "name_native": "Hungarian (Hungary)",
-            "name_english": "Hungarian (Hungary)",
-            "country_english": "Hungary"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hy-AM-AnahitNeural": {
-        "key": "hy-AM-AnahitNeural",
-        "name": "\u0531\u0576\u0561\u0570\u056b\u057f",
-        "language": {
-            "code": "hy-AM",
-            "family": "hy",
-            "region": "AM",
-            "name_native": "Armenian (Armenia)",
-            "name_english": "Armenian (Armenia)",
-            "country_english": "Armenia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "hy-AM-HaykNeural": {
-        "key": "hy-AM-HaykNeural",
-        "name": "\u0540\u0561\u0575\u056f",
-        "language": {
-            "code": "hy-AM",
-            "family": "hy",
-            "region": "AM",
-            "name_native": "Armenian (Armenia)",
-            "name_english": "Armenian (Armenia)",
-            "country_english": "Armenia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "id-ID-GadisNeural": {
-        "key": "id-ID-GadisNeural",
-        "name": "Gadis",
-        "language": {
-            "code": "id-ID",
-            "family": "id",
-            "region": "ID",
-            "name_native": "Indonesian (Indonesia)",
-            "name_english": "Indonesian (Indonesia)",
-            "country_english": "Indonesia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "id-ID-ArdiNeural": {
-        "key": "id-ID-ArdiNeural",
-        "name": "Ardi",
-        "language": {
-            "code": "id-ID",
-            "family": "id",
-            "region": "ID",
-            "name_native": "Indonesian (Indonesia)",
-            "name_english": "Indonesian (Indonesia)",
-            "country_english": "Indonesia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "is-IS-GudrunNeural": {
-        "key": "is-IS-GudrunNeural",
-        "name": "Gu\u00f0r\u00fan",
-        "language": {
-            "code": "is-IS",
-            "family": "is",
-            "region": "IS",
-            "name_native": "Icelandic (Iceland)",
-            "name_english": "Icelandic (Iceland)",
-            "country_english": "Iceland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "is-IS-GunnarNeural": {
-        "key": "is-IS-GunnarNeural",
-        "name": "Gunnar",
-        "language": {
-            "code": "is-IS",
-            "family": "is",
-            "region": "IS",
-            "name_native": "Icelandic (Iceland)",
-            "name_english": "Icelandic (Iceland)",
-            "country_english": "Iceland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-ElsaNeural": {
-        "key": "it-IT-ElsaNeural",
-        "name": "Elsa",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-IsabellaNeural": {
-        "key": "it-IT-IsabellaNeural",
-        "name": "Isabella",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-DiegoNeural": {
-        "key": "it-IT-DiegoNeural",
-        "name": "Diego",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-BenignoNeural": {
-        "key": "it-IT-BenignoNeural",
-        "name": "Benigno",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-CalimeroNeural": {
-        "key": "it-IT-CalimeroNeural",
-        "name": "Calimero",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-CataldoNeural": {
-        "key": "it-IT-CataldoNeural",
-        "name": "Cataldo",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-FabiolaNeural": {
-        "key": "it-IT-FabiolaNeural",
-        "name": "Fabiola",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-FiammaNeural": {
-        "key": "it-IT-FiammaNeural",
-        "name": "Fiamma",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-GianniNeural": {
-        "key": "it-IT-GianniNeural",
-        "name": "Gianni",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-ImeldaNeural": {
-        "key": "it-IT-ImeldaNeural",
-        "name": "Imelda",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-IrmaNeural": {
-        "key": "it-IT-IrmaNeural",
-        "name": "Irma",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-LisandroNeural": {
-        "key": "it-IT-LisandroNeural",
-        "name": "Lisandro",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-PalmiraNeural": {
-        "key": "it-IT-PalmiraNeural",
-        "name": "Palmira",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-PierinaNeural": {
-        "key": "it-IT-PierinaNeural",
-        "name": "Pierina",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "it-IT-RinaldoNeural": {
-        "key": "it-IT-RinaldoNeural",
-        "name": "Rinaldo",
-        "language": {
-            "code": "it-IT",
-            "family": "it",
-            "region": "IT",
-            "name_native": "Italian (Italy)",
-            "name_english": "Italian (Italy)",
-            "country_english": "Italy"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ja-JP-NanamiNeural": {
-        "key": "ja-JP-NanamiNeural",
-        "name": "\u4e03\u6d77",
-        "language": {
-            "code": "ja-JP",
-            "family": "ja",
-            "region": "JP",
-            "name_native": "Japanese (Japan)",
-            "name_english": "Japanese (Japan)",
-            "country_english": "Japan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ja-JP-KeitaNeural": {
-        "key": "ja-JP-KeitaNeural",
-        "name": "\u572d\u592a",
-        "language": {
-            "code": "ja-JP",
-            "family": "ja",
-            "region": "JP",
-            "name_native": "Japanese (Japan)",
-            "name_english": "Japanese (Japan)",
-            "country_english": "Japan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ja-JP-AoiNeural": {
-        "key": "ja-JP-AoiNeural",
-        "name": "\u78a7\u8863",
-        "language": {
-            "code": "ja-JP",
-            "family": "ja",
-            "region": "JP",
-            "name_native": "Japanese (Japan)",
-            "name_english": "Japanese (Japan)",
-            "country_english": "Japan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ja-JP-DaichiNeural": {
-        "key": "ja-JP-DaichiNeural",
-        "name": "\u5927\u667a",
-        "language": {
-            "code": "ja-JP",
-            "family": "ja",
-            "region": "JP",
-            "name_native": "Japanese (Japan)",
-            "name_english": "Japanese (Japan)",
-            "country_english": "Japan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ja-JP-MayuNeural": {
-        "key": "ja-JP-MayuNeural",
-        "name": "\u771f\u5915",
-        "language": {
-            "code": "ja-JP",
-            "family": "ja",
-            "region": "JP",
-            "name_native": "Japanese (Japan)",
-            "name_english": "Japanese (Japan)",
-            "country_english": "Japan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ja-JP-NaokiNeural": {
-        "key": "ja-JP-NaokiNeural",
-        "name": "\u76f4\u7d00",
-        "language": {
-            "code": "ja-JP",
-            "family": "ja",
-            "region": "JP",
-            "name_native": "Japanese (Japan)",
-            "name_english": "Japanese (Japan)",
-            "country_english": "Japan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ja-JP-ShioriNeural": {
-        "key": "ja-JP-ShioriNeural",
-        "name": "\u5fd7\u7e54",
-        "language": {
-            "code": "ja-JP",
-            "family": "ja",
-            "region": "JP",
-            "name_native": "Japanese (Japan)",
-            "name_english": "Japanese (Japan)",
-            "country_english": "Japan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "jv-ID-SitiNeural": {
-        "key": "jv-ID-SitiNeural",
-        "name": "Siti",
-        "language": {
-            "code": "jv-ID",
-            "family": "jv",
-            "region": "ID",
-            "name_native": "Javanese (Latin, Indonesia)",
-            "name_english": "Javanese (Latin, Indonesia)",
-            "country_english": "Indonesia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "jv-ID-DimasNeural": {
-        "key": "jv-ID-DimasNeural",
-        "name": "Dimas",
-        "language": {
-            "code": "jv-ID",
-            "family": "jv",
-            "region": "ID",
-            "name_native": "Javanese (Latin, Indonesia)",
-            "name_english": "Javanese (Latin, Indonesia)",
-            "country_english": "Indonesia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ka-GE-EkaNeural": {
-        "key": "ka-GE-EkaNeural",
-        "name": "\u10d4\u10d9\u10d0",
-        "language": {
-            "code": "ka-GE",
-            "family": "ka",
-            "region": "GE",
-            "name_native": "Georgian (Georgia)",
-            "name_english": "Georgian (Georgia)",
-            "country_english": "Georgia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ka-GE-GiorgiNeural": {
-        "key": "ka-GE-GiorgiNeural",
-        "name": "\u10d2\u10d8\u10dd\u10e0\u10d2\u10d8",
-        "language": {
-            "code": "ka-GE",
-            "family": "ka",
-            "region": "GE",
-            "name_native": "Georgian (Georgia)",
-            "name_english": "Georgian (Georgia)",
-            "country_english": "Georgia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "kk-KZ-AigulNeural": {
-        "key": "kk-KZ-AigulNeural",
-        "name": "\u0410\u0439\u0433\u04af\u043b",
-        "language": {
-            "code": "kk-KZ",
-            "family": "kk",
-            "region": "KZ",
-            "name_native": "Kazakh (Kazakhstan)",
-            "name_english": "Kazakh (Kazakhstan)",
-            "country_english": "Kazakhstan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "kk-KZ-DauletNeural": {
-        "key": "kk-KZ-DauletNeural",
-        "name": "\u0414\u04d9\u0443\u043b\u0435\u0442",
-        "language": {
-            "code": "kk-KZ",
-            "family": "kk",
-            "region": "KZ",
-            "name_native": "Kazakh (Kazakhstan)",
-            "name_english": "Kazakh (Kazakhstan)",
-            "country_english": "Kazakhstan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "km-KH-SreymomNeural": {
-        "key": "km-KH-SreymomNeural",
-        "name": "\u179f\u17d2\u179a\u17b8\u1798\u17bb\u17c6",
-        "language": {
-            "code": "km-KH",
-            "family": "km",
-            "region": "KH",
-            "name_native": "Khmer (Cambodia)",
-            "name_english": "Khmer (Cambodia)",
-            "country_english": "Cambodia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "km-KH-PisethNeural": {
-        "key": "km-KH-PisethNeural",
-        "name": "\u1796\u17b7\u179f\u17b7\u178a\u17d2\u178b",
-        "language": {
-            "code": "km-KH",
-            "family": "km",
-            "region": "KH",
-            "name_native": "Khmer (Cambodia)",
-            "name_english": "Khmer (Cambodia)",
-            "country_english": "Cambodia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "kn-IN-SapnaNeural": {
-        "key": "kn-IN-SapnaNeural",
-        "name": "\u0cb8\u0caa\u0ccd\u0ca8\u0cbe",
-        "language": {
-            "code": "kn-IN",
-            "family": "kn",
-            "region": "IN",
-            "name_native": "Kannada (India)",
-            "name_english": "Kannada (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "kn-IN-GaganNeural": {
-        "key": "kn-IN-GaganNeural",
-        "name": "\u0c97\u0c97\u0ca8\u0ccd",
-        "language": {
-            "code": "kn-IN",
-            "family": "kn",
-            "region": "IN",
-            "name_native": "Kannada (India)",
-            "name_english": "Kannada (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-SunHiNeural": {
-        "key": "ko-KR-SunHiNeural",
-        "name": "\uc120\ud788",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-InJoonNeural": {
-        "key": "ko-KR-InJoonNeural",
-        "name": "\uc778\uc900",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-BongJinNeural": {
-        "key": "ko-KR-BongJinNeural",
-        "name": "\ubd09\uc9c4",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-GookMinNeural": {
-        "key": "ko-KR-GookMinNeural",
-        "name": "\uad6d\ubbfc",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-JiMinNeural": {
-        "key": "ko-KR-JiMinNeural",
-        "name": "\uc9c0\ubbfc",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-SeoHyeonNeural": {
-        "key": "ko-KR-SeoHyeonNeural",
-        "name": "\uc11c\ud604",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-SoonBokNeural": {
-        "key": "ko-KR-SoonBokNeural",
-        "name": "\uc21c\ubcf5",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ko-KR-YuJinNeural": {
-        "key": "ko-KR-YuJinNeural",
-        "name": "\uc720\uc9c4",
-        "language": {
-            "code": "ko-KR",
-            "family": "ko",
-            "region": "KR",
-            "name_native": "Korean (Korea)",
-            "name_english": "Korean (Korea)",
-            "country_english": "Korea, Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "lo-LA-KeomanyNeural": {
-        "key": "lo-LA-KeomanyNeural",
-        "name": "\u0ec1\u0e81\u0ec9\u0ea7\u0ea1\u0eb0\u0e99\u0eb5",
-        "language": {
-            "code": "lo-LA",
-            "family": "lo",
-            "region": "LA",
-            "name_native": "Lao (Laos)",
-            "name_english": "Lao (Laos)",
-            "country_english": "Lao People's Democratic Republic"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "lo-LA-ChanthavongNeural": {
-        "key": "lo-LA-ChanthavongNeural",
-        "name": "\u0e88\u0eb1\u0e99\u0e97\u0eb0\u0ea7\u0ebb\u0e87",
-        "language": {
-            "code": "lo-LA",
-            "family": "lo",
-            "region": "LA",
-            "name_native": "Lao (Laos)",
-            "name_english": "Lao (Laos)",
-            "country_english": "Lao People's Democratic Republic"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "lt-LT-OnaNeural": {
-        "key": "lt-LT-OnaNeural",
-        "name": "Ona",
-        "language": {
-            "code": "lt-LT",
-            "family": "lt",
-            "region": "LT",
-            "name_native": "Lithuanian (Lithuania)",
-            "name_english": "Lithuanian (Lithuania)",
-            "country_english": "Lithuania"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "lt-LT-LeonasNeural": {
-        "key": "lt-LT-LeonasNeural",
-        "name": "Leonas",
-        "language": {
-            "code": "lt-LT",
-            "family": "lt",
-            "region": "LT",
-            "name_native": "Lithuanian (Lithuania)",
-            "name_english": "Lithuanian (Lithuania)",
-            "country_english": "Lithuania"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "lv-LV-EveritaNeural": {
-        "key": "lv-LV-EveritaNeural",
-        "name": "Everita",
-        "language": {
-            "code": "lv-LV",
-            "family": "lv",
-            "region": "LV",
-            "name_native": "Latvian (Latvia)",
-            "name_english": "Latvian (Latvia)",
-            "country_english": "Latvia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "lv-LV-NilsNeural": {
-        "key": "lv-LV-NilsNeural",
-        "name": "Nils",
-        "language": {
-            "code": "lv-LV",
-            "family": "lv",
-            "region": "LV",
-            "name_native": "Latvian (Latvia)",
-            "name_english": "Latvian (Latvia)",
-            "country_english": "Latvia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mk-MK-MarijaNeural": {
-        "key": "mk-MK-MarijaNeural",
-        "name": "\u041c\u0430\u0440\u0438\u0458\u0430",
-        "language": {
-            "code": "mk-MK",
-            "family": "mk",
-            "region": "MK",
-            "name_native": "Macedonian (North Macedonia)",
-            "name_english": "Macedonian (North Macedonia)",
-            "country_english": "North Macedonia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mk-MK-AleksandarNeural": {
-        "key": "mk-MK-AleksandarNeural",
-        "name": "\u0410\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0430\u0440",
-        "language": {
-            "code": "mk-MK",
-            "family": "mk",
-            "region": "MK",
-            "name_native": "Macedonian (North Macedonia)",
-            "name_english": "Macedonian (North Macedonia)",
-            "country_english": "North Macedonia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ml-IN-SobhanaNeural": {
-        "key": "ml-IN-SobhanaNeural",
-        "name": "\u0d36\u0d4b\u0d2d\u0d28",
-        "language": {
-            "code": "ml-IN",
-            "family": "ml",
-            "region": "IN",
-            "name_native": "Malayalam (India)",
-            "name_english": "Malayalam (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ml-IN-MidhunNeural": {
-        "key": "ml-IN-MidhunNeural",
-        "name": "\u0d2e\u0d3f\u0d25\u0d41\u0d7b",
-        "language": {
-            "code": "ml-IN",
-            "family": "ml",
-            "region": "IN",
-            "name_native": "Malayalam (India)",
-            "name_english": "Malayalam (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mn-MN-YesuiNeural": {
-        "key": "mn-MN-YesuiNeural",
-        "name": "\u0415\u0441\u04af\u0439",
-        "language": {
-            "code": "mn-MN",
-            "family": "mn",
-            "region": "MN",
-            "name_native": "Mongolian (Mongolia)",
-            "name_english": "Mongolian (Mongolia)",
-            "country_english": "Mongolia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mn-MN-BataaNeural": {
-        "key": "mn-MN-BataaNeural",
-        "name": "\u0411\u0430\u0442\u0430\u0430",
-        "language": {
-            "code": "mn-MN",
-            "family": "mn",
-            "region": "MN",
-            "name_native": "Mongolian (Mongolia)",
-            "name_english": "Mongolian (Mongolia)",
-            "country_english": "Mongolia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mr-IN-AarohiNeural": {
-        "key": "mr-IN-AarohiNeural",
-        "name": "\u0906\u0930\u094b\u0939\u0940",
-        "language": {
-            "code": "mr-IN",
-            "family": "mr",
-            "region": "IN",
-            "name_native": "Marathi (India)",
-            "name_english": "Marathi (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mr-IN-ManoharNeural": {
-        "key": "mr-IN-ManoharNeural",
-        "name": "\u092e\u0928\u094b\u0939\u0930",
-        "language": {
-            "code": "mr-IN",
-            "family": "mr",
-            "region": "IN",
-            "name_native": "Marathi (India)",
-            "name_english": "Marathi (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ms-MY-YasminNeural": {
-        "key": "ms-MY-YasminNeural",
-        "name": "Yasmin",
-        "language": {
-            "code": "ms-MY",
-            "family": "ms",
-            "region": "MY",
-            "name_native": "Malay (Malaysia)",
-            "name_english": "Malay (Malaysia)",
-            "country_english": "Malaysia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ms-MY-OsmanNeural": {
-        "key": "ms-MY-OsmanNeural",
-        "name": "Osman",
-        "language": {
-            "code": "ms-MY",
-            "family": "ms",
-            "region": "MY",
-            "name_native": "Malay (Malaysia)",
-            "name_english": "Malay (Malaysia)",
-            "country_english": "Malaysia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mt-MT-GraceNeural": {
-        "key": "mt-MT-GraceNeural",
-        "name": "Grace",
-        "language": {
-            "code": "mt-MT",
-            "family": "mt",
-            "region": "MT",
-            "name_native": "Maltese (Malta)",
-            "name_english": "Maltese (Malta)",
-            "country_english": "Malta"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "mt-MT-JosephNeural": {
-        "key": "mt-MT-JosephNeural",
-        "name": "Joseph",
-        "language": {
-            "code": "mt-MT",
-            "family": "mt",
-            "region": "MT",
-            "name_native": "Maltese (Malta)",
-            "name_english": "Maltese (Malta)",
-            "country_english": "Malta"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "my-MM-NilarNeural": {
-        "key": "my-MM-NilarNeural",
-        "name": "\u1014\u102e\u101c\u102c",
-        "language": {
-            "code": "my-MM",
-            "family": "my",
-            "region": "MM",
-            "name_native": "Burmese (Myanmar)",
-            "name_english": "Burmese (Myanmar)",
-            "country_english": "Myanmar"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "my-MM-ThihaNeural": {
-        "key": "my-MM-ThihaNeural",
-        "name": "\u101e\u102e\u101f",
-        "language": {
-            "code": "my-MM",
-            "family": "my",
-            "region": "MM",
-            "name_native": "Burmese (Myanmar)",
-            "name_english": "Burmese (Myanmar)",
-            "country_english": "Myanmar"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nb-NO-PernilleNeural": {
-        "key": "nb-NO-PernilleNeural",
-        "name": "Pernille",
-        "language": {
-            "code": "nb-NO",
-            "family": "nb",
-            "region": "NO",
-            "name_native": "Norwegian Bokm\u00e5l (Norway)",
-            "name_english": "Norwegian Bokm\u00e5l (Norway)",
-            "country_english": "Norway"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nb-NO-FinnNeural": {
-        "key": "nb-NO-FinnNeural",
-        "name": "Finn",
-        "language": {
-            "code": "nb-NO",
-            "family": "nb",
-            "region": "NO",
-            "name_native": "Norwegian Bokm\u00e5l (Norway)",
-            "name_english": "Norwegian Bokm\u00e5l (Norway)",
-            "country_english": "Norway"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nb-NO-IselinNeural": {
-        "key": "nb-NO-IselinNeural",
-        "name": "Iselin",
-        "language": {
-            "code": "nb-NO",
-            "family": "nb",
-            "region": "NO",
-            "name_native": "Norwegian Bokm\u00e5l (Norway)",
-            "name_english": "Norwegian Bokm\u00e5l (Norway)",
-            "country_english": "Norway"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ne-NP-HemkalaNeural": {
-        "key": "ne-NP-HemkalaNeural",
-        "name": "\u0939\u0947\u092e\u0915\u0932\u093e",
-        "language": {
-            "code": "ne-NP",
-            "family": "ne",
-            "region": "NP",
-            "name_native": "Nepali (Nepal)",
-            "name_english": "Nepali (Nepal)",
-            "country_english": "Nepal"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ne-NP-SagarNeural": {
-        "key": "ne-NP-SagarNeural",
-        "name": "\u0938\u093e\u0917\u0930",
-        "language": {
-            "code": "ne-NP",
-            "family": "ne",
-            "region": "NP",
-            "name_native": "Nepali (Nepal)",
-            "name_english": "Nepali (Nepal)",
-            "country_english": "Nepal"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nl-BE-DenaNeural": {
-        "key": "nl-BE-DenaNeural",
-        "name": "Dena",
-        "language": {
-            "code": "nl-BE",
-            "family": "nl",
-            "region": "BE",
-            "name_native": "Dutch (Belgium)",
-            "name_english": "Dutch (Belgium)",
-            "country_english": "Belgium"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nl-BE-ArnaudNeural": {
-        "key": "nl-BE-ArnaudNeural",
-        "name": "Arnaud",
-        "language": {
-            "code": "nl-BE",
-            "family": "nl",
-            "region": "BE",
-            "name_native": "Dutch (Belgium)",
-            "name_english": "Dutch (Belgium)",
-            "country_english": "Belgium"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nl-NL-FennaNeural": {
-        "key": "nl-NL-FennaNeural",
-        "name": "Fenna",
-        "language": {
-            "code": "nl-NL",
-            "family": "nl",
-            "region": "NL",
-            "name_native": "Dutch (Netherlands)",
-            "name_english": "Dutch (Netherlands)",
-            "country_english": "Netherlands"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nl-NL-MaartenNeural": {
-        "key": "nl-NL-MaartenNeural",
-        "name": "Maarten",
-        "language": {
-            "code": "nl-NL",
-            "family": "nl",
-            "region": "NL",
-            "name_native": "Dutch (Netherlands)",
-            "name_english": "Dutch (Netherlands)",
-            "country_english": "Netherlands"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "nl-NL-ColetteNeural": {
-        "key": "nl-NL-ColetteNeural",
-        "name": "Colette",
-        "language": {
-            "code": "nl-NL",
-            "family": "nl",
-            "region": "NL",
-            "name_native": "Dutch (Netherlands)",
-            "name_english": "Dutch (Netherlands)",
-            "country_english": "Netherlands"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pl-PL-AgnieszkaNeural": {
-        "key": "pl-PL-AgnieszkaNeural",
-        "name": "Agnieszka",
-        "language": {
-            "code": "pl-PL",
-            "family": "pl",
-            "region": "PL",
-            "name_native": "Polish (Poland)",
-            "name_english": "Polish (Poland)",
-            "country_english": "Poland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pl-PL-MarekNeural": {
-        "key": "pl-PL-MarekNeural",
-        "name": "Marek",
-        "language": {
-            "code": "pl-PL",
-            "family": "pl",
-            "region": "PL",
-            "name_native": "Polish (Poland)",
-            "name_english": "Polish (Poland)",
-            "country_english": "Poland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pl-PL-ZofiaNeural": {
-        "key": "pl-PL-ZofiaNeural",
-        "name": "Zofia",
-        "language": {
-            "code": "pl-PL",
-            "family": "pl",
-            "region": "PL",
-            "name_native": "Polish (Poland)",
-            "name_english": "Polish (Poland)",
-            "country_english": "Poland"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ps-AF-LatifaNeural": {
-        "key": "ps-AF-LatifaNeural",
-        "name": "\u0644\u0637\u064a\u0641\u0647",
-        "language": {
-            "code": "ps-AF",
-            "family": "ps",
-            "region": "AF",
-            "name_native": "Pashto (Afghanistan)",
-            "name_english": "Pashto (Afghanistan)",
-            "country_english": "Afghanistan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ps-AF-GulNawazNeural": {
-        "key": "ps-AF-GulNawazNeural",
-        "name": " \u06ab\u0644 \u0646\u0648\u0627\u0632",
-        "language": {
-            "code": "ps-AF",
-            "family": "ps",
-            "region": "AF",
-            "name_native": "Pashto (Afghanistan)",
-            "name_english": "Pashto (Afghanistan)",
-            "country_english": "Afghanistan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-FranciscaNeural": {
-        "key": "pt-BR-FranciscaNeural",
-        "name": "Francisca",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-AntonioNeural": {
-        "key": "pt-BR-AntonioNeural",
-        "name": "Ant\u00f4nio",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-BrendaNeural": {
-        "key": "pt-BR-BrendaNeural",
-        "name": "Brenda",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-DonatoNeural": {
-        "key": "pt-BR-DonatoNeural",
-        "name": "Donato",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-ElzaNeural": {
-        "key": "pt-BR-ElzaNeural",
-        "name": "Elza",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-FabioNeural": {
-        "key": "pt-BR-FabioNeural",
-        "name": "Fabio",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-GiovannaNeural": {
-        "key": "pt-BR-GiovannaNeural",
-        "name": "Giovanna",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-HumbertoNeural": {
-        "key": "pt-BR-HumbertoNeural",
-        "name": "Humberto",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-JulioNeural": {
-        "key": "pt-BR-JulioNeural",
-        "name": "Julio",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-LeilaNeural": {
-        "key": "pt-BR-LeilaNeural",
-        "name": "Leila",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-LeticiaNeural": {
-        "key": "pt-BR-LeticiaNeural",
-        "name": "Leticia",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-ManuelaNeural": {
-        "key": "pt-BR-ManuelaNeural",
-        "name": "Manuela",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-NicolauNeural": {
-        "key": "pt-BR-NicolauNeural",
-        "name": "Nicolau",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-ValerioNeural": {
-        "key": "pt-BR-ValerioNeural",
-        "name": "Valerio",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-BR-YaraNeural": {
-        "key": "pt-BR-YaraNeural",
-        "name": "Yara",
-        "language": {
-            "code": "pt-BR",
-            "family": "pt",
-            "region": "BR",
-            "name_native": "Portuguese (Brazil)",
-            "name_english": "Portuguese (Brazil)",
-            "country_english": "Brazil"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-PT-RaquelNeural": {
-        "key": "pt-PT-RaquelNeural",
-        "name": "Raquel",
-        "language": {
-            "code": "pt-PT",
-            "family": "pt",
-            "region": "PT",
-            "name_native": "Portuguese (Portugal)",
-            "name_english": "Portuguese (Portugal)",
-            "country_english": "Portugal"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-PT-DuarteNeural": {
-        "key": "pt-PT-DuarteNeural",
-        "name": "Duarte",
-        "language": {
-            "code": "pt-PT",
-            "family": "pt",
-            "region": "PT",
-            "name_native": "Portuguese (Portugal)",
-            "name_english": "Portuguese (Portugal)",
-            "country_english": "Portugal"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "pt-PT-FernandaNeural": {
-        "key": "pt-PT-FernandaNeural",
-        "name": "Fernanda",
-        "language": {
-            "code": "pt-PT",
-            "family": "pt",
-            "region": "PT",
-            "name_native": "Portuguese (Portugal)",
-            "name_english": "Portuguese (Portugal)",
-            "country_english": "Portugal"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ro-RO-AlinaNeural": {
-        "key": "ro-RO-AlinaNeural",
-        "name": "Alina",
-        "language": {
-            "code": "ro-RO",
-            "family": "ro",
-            "region": "RO",
-            "name_native": "Romanian (Romania)",
-            "name_english": "Romanian (Romania)",
-            "country_english": "Romania"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ro-RO-EmilNeural": {
-        "key": "ro-RO-EmilNeural",
-        "name": "Emil",
-        "language": {
-            "code": "ro-RO",
-            "family": "ro",
-            "region": "RO",
-            "name_native": "Romanian (Romania)",
-            "name_english": "Romanian (Romania)",
-            "country_english": "Romania"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ru-RU-SvetlanaNeural": {
-        "key": "ru-RU-SvetlanaNeural",
-        "name": "\u0421\u0432\u0435\u0442\u043b\u0430\u043d\u0430",
-        "language": {
-            "code": "ru-RU",
-            "family": "ru",
-            "region": "RU",
-            "name_native": "Russian (Russia)",
-            "name_english": "Russian (Russia)",
-            "country_english": "Russian Federation"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ru-RU-DmitryNeural": {
-        "key": "ru-RU-DmitryNeural",
-        "name": "\u0414\u043c\u0438\u0442\u0440\u0438\u0439",
-        "language": {
-            "code": "ru-RU",
-            "family": "ru",
-            "region": "RU",
-            "name_native": "Russian (Russia)",
-            "name_english": "Russian (Russia)",
-            "country_english": "Russian Federation"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ru-RU-DariyaNeural": {
-        "key": "ru-RU-DariyaNeural",
-        "name": "\u0414\u0430\u0440\u0438\u044f",
-        "language": {
-            "code": "ru-RU",
-            "family": "ru",
-            "region": "RU",
-            "name_native": "Russian (Russia)",
-            "name_english": "Russian (Russia)",
-            "country_english": "Russian Federation"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "si-LK-ThiliniNeural": {
-        "key": "si-LK-ThiliniNeural",
-        "name": "\u0dad\u0dd2\u0dc5\u0dd2\u0dab\u0dd2",
-        "language": {
-            "code": "si-LK",
-            "family": "si",
-            "region": "LK",
-            "name_native": "Sinhala (Sri Lanka)",
-            "name_english": "Sinhala (Sri Lanka)",
-            "country_english": "Sri Lanka"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "si-LK-SameeraNeural": {
-        "key": "si-LK-SameeraNeural",
-        "name": "\u0dc3\u0db8\u0dd3\u0dbb",
-        "language": {
-            "code": "si-LK",
-            "family": "si",
-            "region": "LK",
-            "name_native": "Sinhala (Sri Lanka)",
-            "name_english": "Sinhala (Sri Lanka)",
-            "country_english": "Sri Lanka"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sk-SK-ViktoriaNeural": {
-        "key": "sk-SK-ViktoriaNeural",
-        "name": "Vikt\u00f3ria",
-        "language": {
-            "code": "sk-SK",
-            "family": "sk",
-            "region": "SK",
-            "name_native": "Slovak (Slovakia)",
-            "name_english": "Slovak (Slovakia)",
-            "country_english": "Slovakia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sk-SK-LukasNeural": {
-        "key": "sk-SK-LukasNeural",
-        "name": "Luk\u00e1\u0161",
-        "language": {
-            "code": "sk-SK",
-            "family": "sk",
-            "region": "SK",
-            "name_native": "Slovak (Slovakia)",
-            "name_english": "Slovak (Slovakia)",
-            "country_english": "Slovakia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sl-SI-PetraNeural": {
-        "key": "sl-SI-PetraNeural",
-        "name": "Petra",
-        "language": {
-            "code": "sl-SI",
-            "family": "sl",
-            "region": "SI",
-            "name_native": "Slovenian (Slovenia)",
-            "name_english": "Slovenian (Slovenia)",
-            "country_english": "Slovenia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sl-SI-RokNeural": {
-        "key": "sl-SI-RokNeural",
-        "name": "Rok",
-        "language": {
-            "code": "sl-SI",
-            "family": "sl",
-            "region": "SI",
-            "name_native": "Slovenian (Slovenia)",
-            "name_english": "Slovenian (Slovenia)",
-            "country_english": "Slovenia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "so-SO-UbaxNeural": {
-        "key": "so-SO-UbaxNeural",
-        "name": "Ubax",
-        "language": {
-            "code": "so-SO",
-            "family": "so",
-            "region": "SO",
-            "name_native": "Somali (Somalia)",
-            "name_english": "Somali (Somalia)",
-            "country_english": "Somalia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "so-SO-MuuseNeural": {
-        "key": "so-SO-MuuseNeural",
-        "name": "Muuse",
-        "language": {
-            "code": "so-SO",
-            "family": "so",
-            "region": "SO",
-            "name_native": "Somali (Somalia)",
-            "name_english": "Somali (Somalia)",
-            "country_english": "Somalia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sq-AL-AnilaNeural": {
-        "key": "sq-AL-AnilaNeural",
-        "name": "Anila",
-        "language": {
-            "code": "sq-AL",
-            "family": "sq",
-            "region": "AL",
-            "name_native": "Albanian (Albania)",
-            "name_english": "Albanian (Albania)",
-            "country_english": "Albania"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sq-AL-IlirNeural": {
-        "key": "sq-AL-IlirNeural",
-        "name": "Ilir",
-        "language": {
-            "code": "sq-AL",
-            "family": "sq",
-            "region": "AL",
-            "name_native": "Albanian (Albania)",
-            "name_english": "Albanian (Albania)",
-            "country_english": "Albania"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sr-RS-SophieNeural": {
-        "key": "sr-RS-SophieNeural",
-        "name": "\u0421\u043e\u0444\u0438\u0458\u0430",
-        "language": {
-            "code": "sr-RS",
-            "family": "sr",
-            "region": "RS",
-            "name_native": "Serbian (Cyrillic, Serbia)",
-            "name_english": "Serbian (Cyrillic, Serbia)",
-            "country_english": "Serbia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sr-RS-NicholasNeural": {
-        "key": "sr-RS-NicholasNeural",
-        "name": "\u041d\u0438\u043a\u043e\u043b\u0430",
-        "language": {
-            "code": "sr-RS",
-            "family": "sr",
-            "region": "RS",
-            "name_native": "Serbian (Cyrillic, Serbia)",
-            "name_english": "Serbian (Cyrillic, Serbia)",
-            "country_english": "Serbia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "su-ID-TutiNeural": {
-        "key": "su-ID-TutiNeural",
-        "name": "Tuti",
-        "language": {
-            "code": "su-ID",
-            "family": "su",
-            "region": "ID",
-            "name_native": "Sundanese (Indonesia)",
-            "name_english": "Sundanese (Indonesia)",
-            "country_english": "Indonesia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "su-ID-JajangNeural": {
-        "key": "su-ID-JajangNeural",
-        "name": "Jajang",
-        "language": {
-            "code": "su-ID",
-            "family": "su",
-            "region": "ID",
-            "name_native": "Sundanese (Indonesia)",
-            "name_english": "Sundanese (Indonesia)",
-            "country_english": "Indonesia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sv-SE-SofieNeural": {
-        "key": "sv-SE-SofieNeural",
-        "name": "Sofie",
-        "language": {
-            "code": "sv-SE",
-            "family": "sv",
-            "region": "SE",
-            "name_native": "Swedish (Sweden)",
-            "name_english": "Swedish (Sweden)",
-            "country_english": "Sweden"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sv-SE-MattiasNeural": {
-        "key": "sv-SE-MattiasNeural",
-        "name": "Mattias",
-        "language": {
-            "code": "sv-SE",
-            "family": "sv",
-            "region": "SE",
-            "name_native": "Swedish (Sweden)",
-            "name_english": "Swedish (Sweden)",
-            "country_english": "Sweden"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sv-SE-HilleviNeural": {
-        "key": "sv-SE-HilleviNeural",
-        "name": "Hillevi",
-        "language": {
-            "code": "sv-SE",
-            "family": "sv",
-            "region": "SE",
-            "name_native": "Swedish (Sweden)",
-            "name_english": "Swedish (Sweden)",
-            "country_english": "Sweden"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sw-KE-ZuriNeural": {
-        "key": "sw-KE-ZuriNeural",
-        "name": "Zuri",
-        "language": {
-            "code": "sw-KE",
-            "family": "sw",
-            "region": "KE",
-            "name_native": "Swahili (Kenya)",
-            "name_english": "Swahili (Kenya)",
-            "country_english": "Kenya"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sw-KE-RafikiNeural": {
-        "key": "sw-KE-RafikiNeural",
-        "name": "Rafiki",
-        "language": {
-            "code": "sw-KE",
-            "family": "sw",
-            "region": "KE",
-            "name_native": "Swahili (Kenya)",
-            "name_english": "Swahili (Kenya)",
-            "country_english": "Kenya"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sw-TZ-RehemaNeural": {
-        "key": "sw-TZ-RehemaNeural",
-        "name": "Rehema",
-        "language": {
-            "code": "sw-TZ",
-            "family": "sw",
-            "region": "TZ",
-            "name_native": "Swahili (Tanzania)",
-            "name_english": "Swahili (Tanzania)",
-            "country_english": "Tanzania, United Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "sw-TZ-DaudiNeural": {
-        "key": "sw-TZ-DaudiNeural",
-        "name": "Daudi",
-        "language": {
-            "code": "sw-TZ",
-            "family": "sw",
-            "region": "TZ",
-            "name_native": "Swahili (Tanzania)",
-            "name_english": "Swahili (Tanzania)",
-            "country_english": "Tanzania, United Republic of"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-IN-PallaviNeural": {
-        "key": "ta-IN-PallaviNeural",
-        "name": "\u0baa\u0bb2\u0bcd\u0bb2\u0bb5\u0bbf",
-        "language": {
-            "code": "ta-IN",
-            "family": "ta",
-            "region": "IN",
-            "name_native": "Tamil (India)",
-            "name_english": "Tamil (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-IN-ValluvarNeural": {
-        "key": "ta-IN-ValluvarNeural",
-        "name": "\u0bb5\u0bb3\u0bcd\u0bb3\u0bc1\u0bb5\u0bb0\u0bcd",
-        "language": {
-            "code": "ta-IN",
-            "family": "ta",
-            "region": "IN",
-            "name_native": "Tamil (India)",
-            "name_english": "Tamil (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-LK-SaranyaNeural": {
-        "key": "ta-LK-SaranyaNeural",
-        "name": "\u0b9a\u0bb0\u0ba3\u0bcd\u0baf\u0bbe",
-        "language": {
-            "code": "ta-LK",
-            "family": "ta",
-            "region": "LK",
-            "name_native": "Tamil (Sri Lanka)",
-            "name_english": "Tamil (Sri Lanka)",
-            "country_english": "Sri Lanka"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-LK-KumarNeural": {
-        "key": "ta-LK-KumarNeural",
-        "name": "\u0b95\u0bc1\u0bae\u0bbe\u0bb0\u0bcd",
-        "language": {
-            "code": "ta-LK",
-            "family": "ta",
-            "region": "LK",
-            "name_native": "Tamil (Sri Lanka)",
-            "name_english": "Tamil (Sri Lanka)",
-            "country_english": "Sri Lanka"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-MY-KaniNeural": {
-        "key": "ta-MY-KaniNeural",
-        "name": "\u0b95\u0ba9\u0bbf",
-        "language": {
-            "code": "ta-MY",
-            "family": "ta",
-            "region": "MY",
-            "name_native": "Tamil (Malaysia)",
-            "name_english": "Tamil (Malaysia)",
-            "country_english": "Malaysia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-MY-SuryaNeural": {
-        "key": "ta-MY-SuryaNeural",
-        "name": "\u0b9a\u0bc2\u0bb0\u0bcd\u0baf\u0bbe",
-        "language": {
-            "code": "ta-MY",
-            "family": "ta",
-            "region": "MY",
-            "name_native": "Tamil (Malaysia)",
-            "name_english": "Tamil (Malaysia)",
-            "country_english": "Malaysia"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-SG-VenbaNeural": {
-        "key": "ta-SG-VenbaNeural",
-        "name": "\u0bb5\u0bc6\u0ba3\u0bcd\u0baa\u0bbe",
-        "language": {
-            "code": "ta-SG",
-            "family": "ta",
-            "region": "SG",
-            "name_native": "Tamil (Singapore)",
-            "name_english": "Tamil (Singapore)",
-            "country_english": "Singapore"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ta-SG-AnbuNeural": {
-        "key": "ta-SG-AnbuNeural",
-        "name": "\u0b85\u0ba9\u0bcd\u0baa\u0bc1",
-        "language": {
-            "code": "ta-SG",
-            "family": "ta",
-            "region": "SG",
-            "name_native": "Tamil (Singapore)",
-            "name_english": "Tamil (Singapore)",
-            "country_english": "Singapore"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "te-IN-ShrutiNeural": {
-        "key": "te-IN-ShrutiNeural",
-        "name": "\u0c36\u0c4d\u0c30\u0c41\u0c24\u0c3f",
-        "language": {
-            "code": "te-IN",
-            "family": "te",
-            "region": "IN",
-            "name_native": "Telugu (India)",
-            "name_english": "Telugu (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "te-IN-MohanNeural": {
-        "key": "te-IN-MohanNeural",
-        "name": "\u0c2e\u0c4b\u0c39\u0c28\u0c4d",
-        "language": {
-            "code": "te-IN",
-            "family": "te",
-            "region": "IN",
-            "name_native": "Telugu (India)",
-            "name_english": "Telugu (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "th-TH-PremwadeeNeural": {
-        "key": "th-TH-PremwadeeNeural",
-        "name": "\u0e40\u0e1b\u0e23\u0e21\u0e27\u0e14\u0e35",
-        "language": {
-            "code": "th-TH",
-            "family": "th",
-            "region": "TH",
-            "name_native": "Thai (Thailand)",
-            "name_english": "Thai (Thailand)",
-            "country_english": "Thailand"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "th-TH-NiwatNeural": {
-        "key": "th-TH-NiwatNeural",
-        "name": "\u0e19\u0e34\u0e27\u0e31\u0e12\u0e19\u0e4c",
-        "language": {
-            "code": "th-TH",
-            "family": "th",
-            "region": "TH",
-            "name_native": "Thai (Thailand)",
-            "name_english": "Thai (Thailand)",
-            "country_english": "Thailand"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "th-TH-AcharaNeural": {
-        "key": "th-TH-AcharaNeural",
-        "name": "\u0e2d\u0e31\u0e08\u0e09\u0e23\u0e32",
-        "language": {
-            "code": "th-TH",
-            "family": "th",
-            "region": "TH",
-            "name_native": "Thai (Thailand)",
-            "name_english": "Thai (Thailand)",
-            "country_english": "Thailand"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "tr-TR-EmelNeural": {
-        "key": "tr-TR-EmelNeural",
-        "name": "Emel",
-        "language": {
-            "code": "tr-TR",
-            "family": "tr",
-            "region": "TR",
-            "name_native": "Turkish (Turkey)",
-            "name_english": "Turkish (Turkey)",
-            "country_english": "Turkey"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "tr-TR-AhmetNeural": {
-        "key": "tr-TR-AhmetNeural",
-        "name": "Ahmet",
-        "language": {
-            "code": "tr-TR",
-            "family": "tr",
-            "region": "TR",
-            "name_native": "Turkish (Turkey)",
-            "name_english": "Turkish (Turkey)",
-            "country_english": "Turkey"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "uk-UA-PolinaNeural": {
-        "key": "uk-UA-PolinaNeural",
-        "name": "\u041f\u043e\u043b\u0456\u043d\u0430",
-        "language": {
-            "code": "uk-UA",
-            "family": "uk",
-            "region": "UA",
-            "name_native": "Ukrainian (Ukraine)",
-            "name_english": "Ukrainian (Ukraine)",
-            "country_english": "Ukraine"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "uk-UA-OstapNeural": {
-        "key": "uk-UA-OstapNeural",
-        "name": "\u041e\u0441\u0442\u0430\u043f",
-        "language": {
-            "code": "uk-UA",
-            "family": "uk",
-            "region": "UA",
-            "name_native": "Ukrainian (Ukraine)",
-            "name_english": "Ukrainian (Ukraine)",
-            "country_english": "Ukraine"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ur-IN-GulNeural": {
-        "key": "ur-IN-GulNeural",
-        "name": "\u06af\u0644",
-        "language": {
-            "code": "ur-IN",
-            "family": "ur",
-            "region": "IN",
-            "name_native": "Urdu (India)",
-            "name_english": "Urdu (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ur-IN-SalmanNeural": {
-        "key": "ur-IN-SalmanNeural",
-        "name": "\u0633\u0644\u0645\u0627\u0646",
-        "language": {
-            "code": "ur-IN",
-            "family": "ur",
-            "region": "IN",
-            "name_native": "Urdu (India)",
-            "name_english": "Urdu (India)",
-            "country_english": "India"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ur-PK-UzmaNeural": {
-        "key": "ur-PK-UzmaNeural",
-        "name": "\u0639\u0638\u0645\u06cc\u0670",
-        "language": {
-            "code": "ur-PK",
-            "family": "ur",
-            "region": "PK",
-            "name_native": "Urdu (Pakistan)",
-            "name_english": "Urdu (Pakistan)",
-            "country_english": "Pakistan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "ur-PK-AsadNeural": {
-        "key": "ur-PK-AsadNeural",
-        "name": "\u0627\u0633\u062f",
-        "language": {
-            "code": "ur-PK",
-            "family": "ur",
-            "region": "PK",
-            "name_native": "Urdu (Pakistan)",
-            "name_english": "Urdu (Pakistan)",
-            "country_english": "Pakistan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "uz-UZ-MadinaNeural": {
-        "key": "uz-UZ-MadinaNeural",
-        "name": "Madina",
-        "language": {
-            "code": "uz-UZ",
-            "family": "uz",
-            "region": "UZ",
-            "name_native": "Uzbek (Latin, Uzbekistan)",
-            "name_english": "Uzbek (Latin, Uzbekistan)",
-            "country_english": "Uzbekistan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "uz-UZ-SardorNeural": {
-        "key": "uz-UZ-SardorNeural",
-        "name": "Sardor",
-        "language": {
-            "code": "uz-UZ",
-            "family": "uz",
-            "region": "UZ",
-            "name_native": "Uzbek (Latin, Uzbekistan)",
-            "name_english": "Uzbek (Latin, Uzbekistan)",
-            "country_english": "Uzbekistan"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "vi-VN-HoaiMyNeural": {
-        "key": "vi-VN-HoaiMyNeural",
-        "name": "Ho\u00e0i My",
-        "language": {
-            "code": "vi-VN",
-            "family": "vi",
-            "region": "VN",
-            "name_native": "Vietnamese (Vietnam)",
-            "name_english": "Vietnamese (Vietnam)",
-            "country_english": "Viet Nam"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "vi-VN-NamMinhNeural": {
-        "key": "vi-VN-NamMinhNeural",
-        "name": "Nam Minh",
-        "language": {
-            "code": "vi-VN",
-            "family": "vi",
-            "region": "VN",
-            "name_native": "Vietnamese (Vietnam)",
-            "name_english": "Vietnamese (Vietnam)",
-            "country_english": "Viet Nam"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "wuu-CN-XiaotongNeural": {
-        "key": "wuu-CN-XiaotongNeural",
-        "name": "\u6653\u5f64",
-        "language": {
-            "code": "wuu-CN",
-            "family": "wuu",
-            "region": "CN",
-            "name_native": "Chinese (Wu, Simplified)",
-            "name_english": "Chinese (Wu, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "wuu-CN-YunzheNeural": {
-        "key": "wuu-CN-YunzheNeural",
-        "name": "\u4e91\u54f2",
-        "language": {
-            "code": "wuu-CN",
-            "family": "wuu",
-            "region": "CN",
-            "name_native": "Chinese (Wu, Simplified)",
-            "name_english": "Chinese (Wu, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoxiaoNeural": {
-        "key": "zh-CN-XiaoxiaoNeural",
-        "name": "\u6653\u6653",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunxiNeural": {
-        "key": "zh-CN-YunxiNeural",
-        "name": "\u4e91\u5e0c",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunjianNeural": {
-        "key": "zh-CN-YunjianNeural",
-        "name": "\u4e91\u5065",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoyiNeural": {
-        "key": "zh-CN-XiaoyiNeural",
-        "name": "\u6653\u4f0a",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunyangNeural": {
-        "key": "zh-CN-YunyangNeural",
-        "name": "\u4e91\u626c",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaochenNeural": {
-        "key": "zh-CN-XiaochenNeural",
-        "name": "\u6653\u8fb0",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaohanNeural": {
-        "key": "zh-CN-XiaohanNeural",
-        "name": "\u6653\u6db5",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaomengNeural": {
-        "key": "zh-CN-XiaomengNeural",
-        "name": "\u6653\u68a6",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaomoNeural": {
-        "key": "zh-CN-XiaomoNeural",
-        "name": "\u6653\u58a8",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoqiuNeural": {
-        "key": "zh-CN-XiaoqiuNeural",
-        "name": "\u6653\u79cb",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoruiNeural": {
-        "key": "zh-CN-XiaoruiNeural",
-        "name": "\u6653\u777f",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoshuangNeural": {
-        "key": "zh-CN-XiaoshuangNeural",
-        "name": "\u6653\u53cc",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoxuanNeural": {
-        "key": "zh-CN-XiaoxuanNeural",
-        "name": "\u6653\u8431",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoyanNeural": {
-        "key": "zh-CN-XiaoyanNeural",
-        "name": "\u6653\u989c",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaoyouNeural": {
-        "key": "zh-CN-XiaoyouNeural",
-        "name": "\u6653\u60a0",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-XiaozhenNeural": {
-        "key": "zh-CN-XiaozhenNeural",
-        "name": "\u6653\u7504",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunfengNeural": {
-        "key": "zh-CN-YunfengNeural",
-        "name": "\u4e91\u67ab",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunhaoNeural": {
-        "key": "zh-CN-YunhaoNeural",
-        "name": "\u4e91\u7693",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunxiaNeural": {
-        "key": "zh-CN-YunxiaNeural",
-        "name": "\u4e91\u590f",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunyeNeural": {
-        "key": "zh-CN-YunyeNeural",
-        "name": "\u4e91\u91ce",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-YunzeNeural": {
-        "key": "zh-CN-YunzeNeural",
-        "name": "\u4e91\u6cfd",
-        "language": {
-            "code": "zh-CN",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Mandarin, Simplified)",
-            "name_english": "Chinese (Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-henan-YundengNeural": {
-        "key": "zh-CN-henan-YundengNeural",
-        "name": "\u4e91\u767b",
-        "language": {
-            "code": "zh-CN-henan",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Zhongyuan Mandarin Henan, Simplified)",
-            "name_english": "Chinese (Zhongyuan Mandarin Henan, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-liaoning-XiaobeiNeural": {
-        "key": "zh-CN-liaoning-XiaobeiNeural",
-        "name": "\u6653\u5317",
-        "language": {
-            "code": "zh-CN-liaoning",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Northeastern Mandarin, Simplified)",
-            "name_english": "Chinese (Northeastern Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-shaanxi-XiaoniNeural": {
-        "key": "zh-CN-shaanxi-XiaoniNeural",
-        "name": "\u6653\u59ae",
-        "language": {
-            "code": "zh-CN-shaanxi",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Zhongyuan Mandarin Shaanxi, Simplified)",
-            "name_english": "Chinese (Zhongyuan Mandarin Shaanxi, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-shandong-YunxiangNeural": {
-        "key": "zh-CN-shandong-YunxiangNeural",
-        "name": "\u4e91\u7fd4",
-        "language": {
-            "code": "zh-CN-shandong",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Jilu Mandarin, Simplified)",
-            "name_english": "Chinese (Jilu Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-CN-sichuan-YunxiNeural": {
-        "key": "zh-CN-sichuan-YunxiNeural",
-        "name": "\u4e91\u5e0c\u56db\u5ddd",
-        "language": {
-            "code": "zh-CN-sichuan",
-            "family": "zh",
-            "region": "CN",
-            "name_native": "Chinese (Southwestern Mandarin, Simplified)",
-            "name_english": "Chinese (Southwestern Mandarin, Simplified)",
-            "country_english": "China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-HK-HiuMaanNeural": {
-        "key": "zh-HK-HiuMaanNeural",
-        "name": "\u66c9\u66fc",
-        "language": {
-            "code": "zh-HK",
-            "family": "zh",
-            "region": "HK",
-            "name_native": "Chinese (Cantonese, Traditional)",
-            "name_english": "Chinese (Cantonese, Traditional)",
-            "country_english": "Hong Kong"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-HK-WanLungNeural": {
-        "key": "zh-HK-WanLungNeural",
-        "name": "\u96f2\u9f8d",
-        "language": {
-            "code": "zh-HK",
-            "family": "zh",
-            "region": "HK",
-            "name_native": "Chinese (Cantonese, Traditional)",
-            "name_english": "Chinese (Cantonese, Traditional)",
-            "country_english": "Hong Kong"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-HK-HiuGaaiNeural": {
-        "key": "zh-HK-HiuGaaiNeural",
-        "name": "\u66c9\u4f73",
-        "language": {
-            "code": "zh-HK",
-            "family": "zh",
-            "region": "HK",
-            "name_native": "Chinese (Cantonese, Traditional)",
-            "name_english": "Chinese (Cantonese, Traditional)",
-            "country_english": "Hong Kong"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-TW-HsiaoChenNeural": {
-        "key": "zh-TW-HsiaoChenNeural",
-        "name": "\u66c9\u81fb",
-        "language": {
-            "code": "zh-TW",
-            "family": "zh",
-            "region": "TW",
-            "name_native": "Chinese (Taiwanese Mandarin, Traditional)",
-            "name_english": "Chinese (Taiwanese Mandarin, Traditional)",
-            "country_english": "Taiwan, Province of China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-TW-YunJheNeural": {
-        "key": "zh-TW-YunJheNeural",
-        "name": "\u96f2\u54f2",
-        "language": {
-            "code": "zh-TW",
-            "family": "zh",
-            "region": "TW",
-            "name_native": "Chinese (Taiwanese Mandarin, Traditional)",
-            "name_english": "Chinese (Taiwanese Mandarin, Traditional)",
-            "country_english": "Taiwan, Province of China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zh-TW-HsiaoYuNeural": {
-        "key": "zh-TW-HsiaoYuNeural",
-        "name": "\u66c9\u96e8",
-        "language": {
-            "code": "zh-TW",
-            "family": "zh",
-            "region": "TW",
-            "name_native": "Chinese (Taiwanese Mandarin, Traditional)",
-            "name_english": "Chinese (Taiwanese Mandarin, Traditional)",
-            "country_english": "Taiwan, Province of China"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zu-ZA-ThandoNeural": {
-        "key": "zu-ZA-ThandoNeural",
-        "name": "Thando",
-        "language": {
-            "code": "zu-ZA",
-            "family": "zu",
-            "region": "ZA",
-            "name_native": "Zulu (South Africa)",
-            "name_english": "Zulu (South Africa)",
-            "country_english": "South Africa"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
-    },
-    "zu-ZA-ThembaNeural": {
-        "key": "zu-ZA-ThembaNeural",
-        "name": "Themba",
-        "language": {
-            "code": "zu-ZA",
-            "family": "zu",
-            "region": "ZA",
-            "name_native": "Zulu (South Africa)",
-            "name_english": "Zulu (South Africa)",
-            "country_english": "South Africa"
-        },
-        "quality": "Neural",
-        "num_speakers": 1,
-        "speaker_id_map": {},
-        "aliases": []
+[
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (af-ZA, AdriNeural)",
+    "DisplayName": "Adri",
+    "LocalName": "Adri",
+    "ShortName": "af-ZA-AdriNeural",
+    "Gender": "Female",
+    "Locale": "af-ZA",
+    "LocaleName": "Afrikaans (South Africa)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Well-Rounded",
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "147"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (af-ZA, WillemNeural)",
+    "DisplayName": "Willem",
+    "LocalName": "Willem",
+    "ShortName": "af-ZA-WillemNeural",
+    "Gender": "Male",
+    "Locale": "af-ZA",
+    "LocaleName": "Afrikaans (South Africa)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (am-ET, MekdesNeural)",
+    "DisplayName": "Mekdes",
+    "LocalName": "መቅደስ",
+    "ShortName": "am-ET-MekdesNeural",
+    "Gender": "Female",
+    "Locale": "am-ET",
+    "LocaleName": "Amharic (Ethiopia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "117"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (am-ET, AmehaNeural)",
+    "DisplayName": "Ameha",
+    "LocalName": "አምሀ",
+    "ShortName": "am-ET-AmehaNeural",
+    "Gender": "Male",
+    "Locale": "am-ET",
+    "LocaleName": "Amharic (Ethiopia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "112"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-AE, FatimaNeural)",
+    "DisplayName": "Fatima",
+    "LocalName": "فاطمة",
+    "ShortName": "ar-AE-FatimaNeural",
+    "Gender": "Female",
+    "Locale": "ar-AE",
+    "LocaleName": "Arabic (United Arab Emirates)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "110"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-AE, HamdanNeural)",
+    "DisplayName": "Hamdan",
+    "LocalName": "حمدان",
+    "ShortName": "ar-AE-HamdanNeural",
+    "Gender": "Male",
+    "Locale": "ar-AE",
+    "LocaleName": "Arabic (United Arab Emirates)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "115"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-BH, LailaNeural)",
+    "DisplayName": "Laila",
+    "LocalName": "ليلى",
+    "ShortName": "ar-BH-LailaNeural",
+    "Gender": "Female",
+    "Locale": "ar-BH",
+    "LocaleName": "Arabic (Bahrain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "108"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-BH, AliNeural)",
+    "DisplayName": "Ali",
+    "LocalName": "علي",
+    "ShortName": "ar-BH-AliNeural",
+    "Gender": "Male",
+    "Locale": "ar-BH",
+    "LocaleName": "Arabic (Bahrain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "121"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-DZ, AminaNeural)",
+    "DisplayName": "Amina",
+    "LocalName": "أمينة",
+    "ShortName": "ar-DZ-AminaNeural",
+    "Gender": "Female",
+    "Locale": "ar-DZ",
+    "LocaleName": "Arabic (Algeria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "110"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-DZ, IsmaelNeural)",
+    "DisplayName": "Ismael",
+    "LocalName": "إسماعيل",
+    "ShortName": "ar-DZ-IsmaelNeural",
+    "Gender": "Male",
+    "Locale": "ar-DZ",
+    "LocaleName": "Arabic (Algeria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "115"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-EG, SalmaNeural)",
+    "DisplayName": "Salma",
+    "LocalName": "سلمى",
+    "ShortName": "ar-EG-SalmaNeural",
+    "Gender": "Female",
+    "Locale": "ar-EG",
+    "LocaleName": "Arabic (Egypt)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "103"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-EG, ShakirNeural)",
+    "DisplayName": "Shakir",
+    "LocalName": "شاكر",
+    "ShortName": "ar-EG-ShakirNeural",
+    "Gender": "Male",
+    "Locale": "ar-EG",
+    "LocaleName": "Arabic (Egypt)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "115"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-IQ, RanaNeural)",
+    "DisplayName": "Rana",
+    "LocalName": "رنا",
+    "ShortName": "ar-IQ-RanaNeural",
+    "Gender": "Female",
+    "Locale": "ar-IQ",
+    "LocaleName": "Arabic (Iraq)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "98"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-IQ, BasselNeural)",
+    "DisplayName": "Bassel",
+    "LocalName": "باسل",
+    "ShortName": "ar-IQ-BasselNeural",
+    "Gender": "Male",
+    "Locale": "ar-IQ",
+    "LocaleName": "Arabic (Iraq)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-JO, SanaNeural)",
+    "DisplayName": "Sana",
+    "LocalName": "سناء",
+    "ShortName": "ar-JO-SanaNeural",
+    "Gender": "Female",
+    "Locale": "ar-JO",
+    "LocaleName": "Arabic (Jordan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "98"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-JO, TaimNeural)",
+    "DisplayName": "Taim",
+    "LocalName": "تيم",
+    "ShortName": "ar-JO-TaimNeural",
+    "Gender": "Male",
+    "Locale": "ar-JO",
+    "LocaleName": "Arabic (Jordan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-KW, NouraNeural)",
+    "DisplayName": "Noura",
+    "LocalName": "نورا",
+    "ShortName": "ar-KW-NouraNeural",
+    "Gender": "Female",
+    "Locale": "ar-KW",
+    "LocaleName": "Arabic (Kuwait)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "121"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-KW, FahedNeural)",
+    "DisplayName": "Fahed",
+    "LocalName": "فهد",
+    "ShortName": "ar-KW-FahedNeural",
+    "Gender": "Male",
+    "Locale": "ar-KW",
+    "LocaleName": "Arabic (Kuwait)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-LB, LaylaNeural)",
+    "DisplayName": "Layla",
+    "LocalName": "ليلى",
+    "ShortName": "ar-LB-LaylaNeural",
+    "Gender": "Female",
+    "Locale": "ar-LB",
+    "LocaleName": "Arabic (Lebanon)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "99"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-LB, RamiNeural)",
+    "DisplayName": "Rami",
+    "LocalName": "رامي",
+    "ShortName": "ar-LB-RamiNeural",
+    "Gender": "Male",
+    "Locale": "ar-LB",
+    "LocaleName": "Arabic (Lebanon)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "101"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-LY, ImanNeural)",
+    "DisplayName": "Iman",
+    "LocalName": "إيمان",
+    "ShortName": "ar-LY-ImanNeural",
+    "Gender": "Female",
+    "Locale": "ar-LY",
+    "LocaleName": "Arabic (Libya)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "108"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-LY, OmarNeural)",
+    "DisplayName": "Omar",
+    "LocalName": "أحمد",
+    "ShortName": "ar-LY-OmarNeural",
+    "Gender": "Male",
+    "Locale": "ar-LY",
+    "LocaleName": "Arabic (Libya)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "111"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-MA, MounaNeural)",
+    "DisplayName": "Mouna",
+    "LocalName": "منى",
+    "ShortName": "ar-MA-MounaNeural",
+    "Gender": "Female",
+    "Locale": "ar-MA",
+    "LocaleName": "Arabic (Morocco)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "121"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-MA, JamalNeural)",
+    "DisplayName": "Jamal",
+    "LocalName": "جمال",
+    "ShortName": "ar-MA-JamalNeural",
+    "Gender": "Male",
+    "Locale": "ar-MA",
+    "LocaleName": "Arabic (Morocco)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-OM, AyshaNeural)",
+    "DisplayName": "Aysha",
+    "LocalName": "عائشة",
+    "ShortName": "ar-OM-AyshaNeural",
+    "Gender": "Female",
+    "Locale": "ar-OM",
+    "LocaleName": "Arabic (Oman)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Pleasant"
+      ]
+    },
+    "WordsPerMinute": "118"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-OM, AbdullahNeural)",
+    "DisplayName": "Abdullah",
+    "LocalName": "عبدالله",
+    "ShortName": "ar-OM-AbdullahNeural",
+    "Gender": "Male",
+    "Locale": "ar-OM",
+    "LocaleName": "Arabic (Oman)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "123"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-QA, AmalNeural)",
+    "DisplayName": "Amal",
+    "LocalName": "أمل",
+    "ShortName": "ar-QA-AmalNeural",
+    "Gender": "Female",
+    "Locale": "ar-QA",
+    "LocaleName": "Arabic (Qatar)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-QA, MoazNeural)",
+    "DisplayName": "Moaz",
+    "LocalName": "معاذ",
+    "ShortName": "ar-QA-MoazNeural",
+    "Gender": "Male",
+    "Locale": "ar-QA",
+    "LocaleName": "Arabic (Qatar)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-SA, ZariyahNeural)",
+    "DisplayName": "Zariyah",
+    "LocalName": "زارية",
+    "ShortName": "ar-SA-ZariyahNeural",
+    "Gender": "Female",
+    "Locale": "ar-SA",
+    "LocaleName": "Arabic (Saudi Arabia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "105"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-SA, HamedNeural)",
+    "DisplayName": "Hamed",
+    "LocalName": "حامد",
+    "ShortName": "ar-SA-HamedNeural",
+    "Gender": "Male",
+    "Locale": "ar-SA",
+    "LocaleName": "Arabic (Saudi Arabia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "107"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-SY, AmanyNeural)",
+    "DisplayName": "Amany",
+    "LocalName": "أماني",
+    "ShortName": "ar-SY-AmanyNeural",
+    "Gender": "Female",
+    "Locale": "ar-SY",
+    "LocaleName": "Arabic (Syria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Pleasant"
+      ]
+    },
+    "WordsPerMinute": "122"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-SY, LaithNeural)",
+    "DisplayName": "Laith",
+    "LocalName": "ليث",
+    "ShortName": "ar-SY-LaithNeural",
+    "Gender": "Male",
+    "Locale": "ar-SY",
+    "LocaleName": "Arabic (Syria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-TN, ReemNeural)",
+    "DisplayName": "Reem",
+    "LocalName": "ريم",
+    "ShortName": "ar-TN-ReemNeural",
+    "Gender": "Female",
+    "Locale": "ar-TN",
+    "LocaleName": "Arabic (Tunisia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Pleasant"
+      ]
+    },
+    "WordsPerMinute": "112"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-TN, HediNeural)",
+    "DisplayName": "Hedi",
+    "LocalName": "هادي",
+    "ShortName": "ar-TN-HediNeural",
+    "Gender": "Male",
+    "Locale": "ar-TN",
+    "LocaleName": "Arabic (Tunisia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "118"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-YE, MaryamNeural)",
+    "DisplayName": "Maryam",
+    "LocalName": "مريم",
+    "ShortName": "ar-YE-MaryamNeural",
+    "Gender": "Female",
+    "Locale": "ar-YE",
+    "LocaleName": "Arabic (Yemen)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "108"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ar-YE, SalehNeural)",
+    "DisplayName": "Saleh",
+    "LocalName": "صالح",
+    "ShortName": "ar-YE-SalehNeural",
+    "Gender": "Male",
+    "Locale": "ar-YE",
+    "LocaleName": "Arabic (Yemen)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "115"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (as-IN, YashicaNeural)",
+    "DisplayName": "Yashica",
+    "LocalName": "যাশিকা",
+    "ShortName": "as-IN-YashicaNeural",
+    "Gender": "Female",
+    "Locale": "as-IN",
+    "LocaleName": "Assamese (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (as-IN, PriyomNeural)",
+    "DisplayName": "Priyom",
+    "LocalName": "প্ৰিয়ম",
+    "ShortName": "as-IN-PriyomNeural",
+    "Gender": "Male",
+    "Locale": "as-IN",
+    "LocaleName": "Assamese (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (az-AZ, BanuNeural)",
+    "DisplayName": "Banu",
+    "LocalName": "Banu",
+    "ShortName": "az-AZ-BanuNeural",
+    "Gender": "Female",
+    "Locale": "az-AZ",
+    "LocaleName": "Azerbaijani (Latin, Azerbaijan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (az-AZ, BabekNeural)",
+    "DisplayName": "Babek",
+    "LocalName": "Babək",
+    "ShortName": "az-AZ-BabekNeural",
+    "Gender": "Male",
+    "Locale": "az-AZ",
+    "LocaleName": "Azerbaijani (Latin, Azerbaijan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bg-BG, KalinaNeural)",
+    "DisplayName": "Kalina",
+    "LocalName": "Калина",
+    "ShortName": "bg-BG-KalinaNeural",
+    "Gender": "Female",
+    "Locale": "bg-BG",
+    "LocaleName": "Bulgarian (Bulgaria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "125"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bg-BG, BorislavNeural)",
+    "DisplayName": "Borislav",
+    "LocalName": "Борислав",
+    "ShortName": "bg-BG-BorislavNeural",
+    "Gender": "Male",
+    "Locale": "bg-BG",
+    "LocaleName": "Bulgarian (Bulgaria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Light-Hearted",
+        "Whimsical",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "132"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bn-BD, NabanitaNeural)",
+    "DisplayName": "Nabanita",
+    "LocalName": "নবনীতা",
+    "ShortName": "bn-BD-NabanitaNeural",
+    "Gender": "Female",
+    "Locale": "bn-BD",
+    "LocaleName": "Bangla (Bangladesh)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "123"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bn-BD, PradeepNeural)",
+    "DisplayName": "Pradeep",
+    "LocalName": "প্রদ্বীপ",
+    "ShortName": "bn-BD-PradeepNeural",
+    "Gender": "Male",
+    "Locale": "bn-BD",
+    "LocaleName": "Bangla (Bangladesh)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "125"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bn-IN, TanishaaNeural)",
+    "DisplayName": "Tanishaa",
+    "LocalName": "তানিশা",
+    "ShortName": "bn-IN-TanishaaNeural",
+    "Gender": "Female",
+    "Locale": "bn-IN",
+    "LocaleName": "Bengali (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "123"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bn-IN, BashkarNeural)",
+    "DisplayName": "Bashkar",
+    "LocalName": "ভাস্কর",
+    "ShortName": "bn-IN-BashkarNeural",
+    "Gender": "Male",
+    "Locale": "bn-IN",
+    "LocaleName": "Bengali (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "131"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bs-BA, VesnaNeural)",
+    "DisplayName": "Vesna",
+    "LocalName": "Vesna",
+    "ShortName": "bs-BA-VesnaNeural",
+    "Gender": "Female",
+    "Locale": "bs-BA",
+    "LocaleName": "Bosnian (Bosnia and Herzegovina)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (bs-BA, GoranNeural)",
+    "DisplayName": "Goran",
+    "LocalName": "Goran",
+    "ShortName": "bs-BA-GoranNeural",
+    "Gender": "Male",
+    "Locale": "bs-BA",
+    "LocaleName": "Bosnian (Bosnia and Herzegovina)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ca-ES, JoanaNeural)",
+    "DisplayName": "Joana",
+    "LocalName": "Joana",
+    "ShortName": "ca-ES-JoanaNeural",
+    "Gender": "Female",
+    "Locale": "ca-ES",
+    "LocaleName": "Catalan",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "147"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ca-ES, EnricNeural)",
+    "DisplayName": "Enric",
+    "LocalName": "Enric",
+    "ShortName": "ca-ES-EnricNeural",
+    "Gender": "Male",
+    "Locale": "ca-ES",
+    "LocaleName": "Catalan",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ca-ES, AlbaNeural)",
+    "DisplayName": "Alba",
+    "LocalName": "Alba",
+    "ShortName": "ca-ES-AlbaNeural",
+    "Gender": "Female",
+    "Locale": "ca-ES",
+    "LocaleName": "Catalan",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (cs-CZ, VlastaNeural)",
+    "DisplayName": "Vlasta",
+    "LocalName": "Vlasta",
+    "ShortName": "cs-CZ-VlastaNeural",
+    "Gender": "Female",
+    "Locale": "cs-CZ",
+    "LocaleName": "Czech (Czechia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "118"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (cs-CZ, AntoninNeural)",
+    "DisplayName": "Antonin",
+    "LocalName": "Antonín",
+    "ShortName": "cs-CZ-AntoninNeural",
+    "Gender": "Male",
+    "Locale": "cs-CZ",
+    "LocaleName": "Czech (Czechia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (cy-GB, NiaNeural)",
+    "DisplayName": "Nia",
+    "LocalName": "Nia",
+    "ShortName": "cy-GB-NiaNeural",
+    "Gender": "Female",
+    "Locale": "cy-GB",
+    "LocaleName": "Welsh (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "136"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (cy-GB, AledNeural)",
+    "DisplayName": "Aled",
+    "LocalName": "Aled",
+    "ShortName": "cy-GB-AledNeural",
+    "Gender": "Male",
+    "Locale": "cy-GB",
+    "LocaleName": "Welsh (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (da-DK, ChristelNeural)",
+    "DisplayName": "Christel",
+    "LocalName": "Christel",
+    "ShortName": "da-DK-ChristelNeural",
+    "Gender": "Female",
+    "Locale": "da-DK",
+    "LocaleName": "Danish (Denmark)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (da-DK, JeppeNeural)",
+    "DisplayName": "Jeppe",
+    "LocalName": "Jeppe",
+    "ShortName": "da-DK-JeppeNeural",
+    "Gender": "Male",
+    "Locale": "da-DK",
+    "LocaleName": "Danish (Denmark)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "147"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-AT, IngridNeural)",
+    "DisplayName": "Ingrid",
+    "LocalName": "Ingrid",
+    "ShortName": "de-AT-IngridNeural",
+    "Gender": "Female",
+    "Locale": "de-AT",
+    "LocaleName": "German (Austria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-AT, JonasNeural)",
+    "DisplayName": "Jonas",
+    "LocalName": "Jonas",
+    "ShortName": "de-AT-JonasNeural",
+    "Gender": "Male",
+    "Locale": "de-AT",
+    "LocaleName": "German (Austria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Light-Hearted",
+        "Whimsical",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "130"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-CH, LeniNeural)",
+    "DisplayName": "Leni",
+    "LocalName": "Leni",
+    "ShortName": "de-CH-LeniNeural",
+    "Gender": "Female",
+    "Locale": "de-CH",
+    "LocaleName": "German (Switzerland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "121"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-CH, JanNeural)",
+    "DisplayName": "Jan",
+    "LocalName": "Jan",
+    "ShortName": "de-CH-JanNeural",
+    "Gender": "Male",
+    "Locale": "de-CH",
+    "LocaleName": "German (Switzerland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, KatjaNeural)",
+    "DisplayName": "Katja",
+    "LocalName": "Katja",
+    "ShortName": "de-DE-KatjaNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Calm",
+        "Pleasant"
+      ]
+    },
+    "WordsPerMinute": "121"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, ConradNeural)",
+    "DisplayName": "Conrad",
+    "LocalName": "Conrad",
+    "ShortName": "de-DE-ConradNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "StyleList": [
+      "cheerful"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Engaging",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, SeraphinaMultilingualNeural)",
+    "DisplayName": "Seraphina Multilingual",
+    "LocalName": "Seraphina Mehrsprachig",
+    "ShortName": "de-DE-SeraphinaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Casual"
+      ]
+    },
+    "WordsPerMinute": "190"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, FlorianMultilingualNeural)",
+    "DisplayName": "Florian Multilingual",
+    "LocalName": "Florian Mehrsprachig",
+    "ShortName": "de-DE-FlorianMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Warm"
+      ]
+    },
+    "WordsPerMinute": "190"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, AmalaNeural)",
+    "DisplayName": "Amala",
+    "LocalName": "Amala",
+    "ShortName": "de-DE-AmalaNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Well-Rounded",
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "115"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, BerndNeural)",
+    "DisplayName": "Bernd",
+    "LocalName": "Bernd",
+    "ShortName": "de-DE-BerndNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "123"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, ChristophNeural)",
+    "DisplayName": "Christoph",
+    "LocalName": "Christoph",
+    "ShortName": "de-DE-ChristophNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, ElkeNeural)",
+    "DisplayName": "Elke",
+    "LocalName": "Elke",
+    "ShortName": "de-DE-ElkeNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, GiselaNeural)",
+    "DisplayName": "Gisela",
+    "LocalName": "Gisela",
+    "ShortName": "de-DE-GiselaNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Cheerful",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "110"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, KasperNeural)",
+    "DisplayName": "Kasper",
+    "LocalName": "Kasper",
+    "ShortName": "de-DE-KasperNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "129"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, KillianNeural)",
+    "DisplayName": "Killian",
+    "LocalName": "Killian",
+    "ShortName": "de-DE-KillianNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "126"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, KlarissaNeural)",
+    "DisplayName": "Klarissa",
+    "LocalName": "Klarissa",
+    "ShortName": "de-DE-KlarissaNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "116"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, KlausNeural)",
+    "DisplayName": "Klaus",
+    "LocalName": "Klaus",
+    "ShortName": "de-DE-KlausNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "106"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, LouisaNeural)",
+    "DisplayName": "Louisa",
+    "LocalName": "Louisa",
+    "ShortName": "de-DE-LouisaNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, MajaNeural)",
+    "DisplayName": "Maja",
+    "LocalName": "Maja",
+    "ShortName": "de-DE-MajaNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "116"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, RalfNeural)",
+    "DisplayName": "Ralf",
+    "LocalName": "Ralf",
+    "ShortName": "de-DE-RalfNeural",
+    "Gender": "Male",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "127"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (de-DE, TanjaNeural)",
+    "DisplayName": "Tanja",
+    "LocalName": "Tanja",
+    "ShortName": "de-DE-TanjaNeural",
+    "Gender": "Female",
+    "Locale": "de-DE",
+    "LocaleName": "German (Germany)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (el-GR, AthinaNeural)",
+    "DisplayName": "Athina",
+    "LocalName": "Αθηνά",
+    "ShortName": "el-GR-AthinaNeural",
+    "Gender": "Female",
+    "Locale": "el-GR",
+    "LocaleName": "Greek (Greece)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "156"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (el-GR, NestorasNeural)",
+    "DisplayName": "Nestoras",
+    "LocalName": "Νέστορας",
+    "ShortName": "el-GR-NestorasNeural",
+    "Gender": "Male",
+    "Locale": "el-GR",
+    "LocaleName": "Greek (Greece)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "158"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, NatashaNeural)",
+    "DisplayName": "Natasha",
+    "LocalName": "Natasha",
+    "ShortName": "en-AU-NatashaNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "139"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, WilliamNeural)",
+    "DisplayName": "William",
+    "LocalName": "William",
+    "ShortName": "en-AU-WilliamNeural",
+    "Gender": "Male",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Engaging",
+        "Strong"
+      ]
+    },
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, AnnetteNeural)",
+    "DisplayName": "Annette",
+    "LocalName": "Annette",
+    "ShortName": "en-AU-AnnetteNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, CarlyNeural)",
+    "DisplayName": "Carly",
+    "LocalName": "Carly",
+    "ShortName": "en-AU-CarlyNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Cheerful",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "137"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, DarrenNeural)",
+    "DisplayName": "Darren",
+    "LocalName": "Darren",
+    "ShortName": "en-AU-DarrenNeural",
+    "Gender": "Male",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "159"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, DuncanNeural)",
+    "DisplayName": "Duncan",
+    "LocalName": "Duncan",
+    "ShortName": "en-AU-DuncanNeural",
+    "Gender": "Male",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "153"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, ElsieNeural)",
+    "DisplayName": "Elsie",
+    "LocalName": "Elsie",
+    "ShortName": "en-AU-ElsieNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, FreyaNeural)",
+    "DisplayName": "Freya",
+    "LocalName": "Freya",
+    "ShortName": "en-AU-FreyaNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, JoanneNeural)",
+    "DisplayName": "Joanne",
+    "LocalName": "Joanne",
+    "ShortName": "en-AU-JoanneNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "153"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, KenNeural)",
+    "DisplayName": "Ken",
+    "LocalName": "Ken",
+    "ShortName": "en-AU-KenNeural",
+    "Gender": "Male",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "159"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, KimNeural)",
+    "DisplayName": "Kim",
+    "LocalName": "Kim",
+    "ShortName": "en-AU-KimNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, NeilNeural)",
+    "DisplayName": "Neil",
+    "LocalName": "Neil",
+    "ShortName": "en-AU-NeilNeural",
+    "Gender": "Male",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, TimNeural)",
+    "DisplayName": "Tim",
+    "LocalName": "Tim",
+    "ShortName": "en-AU-TimNeural",
+    "Gender": "Male",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-AU, TinaNeural)",
+    "DisplayName": "Tina",
+    "LocalName": "Tina",
+    "ShortName": "en-AU-TinaNeural",
+    "Gender": "Female",
+    "Locale": "en-AU",
+    "LocaleName": "English (Australia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "136"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-CA, ClaraNeural)",
+    "DisplayName": "Clara",
+    "LocalName": "Clara",
+    "ShortName": "en-CA-ClaraNeural",
+    "Gender": "Female",
+    "Locale": "en-CA",
+    "LocaleName": "English (Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "167"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-CA, LiamNeural)",
+    "DisplayName": "Liam",
+    "LocalName": "Liam",
+    "ShortName": "en-CA-LiamNeural",
+    "Gender": "Male",
+    "Locale": "en-CA",
+    "LocaleName": "English (Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "180"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, SoniaNeural)",
+    "DisplayName": "Sonia",
+    "LocalName": "Sonia",
+    "ShortName": "en-GB-SoniaNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "StyleList": [
+      "cheerful",
+      "sad"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Gentle",
+        "Soft"
+      ]
+    },
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, RyanNeural)",
+    "DisplayName": "Ryan",
+    "LocalName": "Ryan",
+    "ShortName": "en-GB-RyanNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "StyleList": [
+      "cheerful",
+      "chat"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Engaging"
+      ]
+    },
+    "WordsPerMinute": "161"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, LibbyNeural)",
+    "DisplayName": "Libby",
+    "LocalName": "Libby",
+    "ShortName": "en-GB-LibbyNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, AdaMultilingualNeural)",
+    "DisplayName": "Ada Multilingual",
+    "LocalName": "Ada Multilingual",
+    "ShortName": "en-GB-AdaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Warm",
+        "Gentle",
+        "Friendly"
+      ]
     }
-}
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, OllieMultilingualNeural)",
+    "DisplayName": "Ollie Multilingual",
+    "LocalName": "Ollie Multilingual",
+    "ShortName": "en-GB-OllieMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Cheerful",
+        "Casual",
+        "Friendly",
+        "Pleasant"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, AbbiNeural)",
+    "DisplayName": "Abbi",
+    "LocalName": "Abbi",
+    "ShortName": "en-GB-AbbiNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "145"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, AlfieNeural)",
+    "DisplayName": "Alfie",
+    "LocalName": "Alfie",
+    "ShortName": "en-GB-AlfieNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, BellaNeural)",
+    "DisplayName": "Bella",
+    "LocalName": "Bella",
+    "ShortName": "en-GB-BellaNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "146"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, ElliotNeural)",
+    "DisplayName": "Elliot",
+    "LocalName": "Elliot",
+    "ShortName": "en-GB-ElliotNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, EthanNeural)",
+    "DisplayName": "Ethan",
+    "LocalName": "Ethan",
+    "ShortName": "en-GB-EthanNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, HollieNeural)",
+    "DisplayName": "Hollie",
+    "LocalName": "Hollie",
+    "ShortName": "en-GB-HollieNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, MaisieNeural)",
+    "DisplayName": "Maisie",
+    "LocalName": "Maisie",
+    "ShortName": "en-GB-MaisieNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Cheerful",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, NoahNeural)",
+    "DisplayName": "Noah",
+    "LocalName": "Noah",
+    "ShortName": "en-GB-NoahNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, OliverNeural)",
+    "DisplayName": "Oliver",
+    "LocalName": "Oliver",
+    "ShortName": "en-GB-OliverNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, OliviaNeural)",
+    "DisplayName": "Olivia",
+    "LocalName": "Olivia",
+    "ShortName": "en-GB-OliviaNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, ThomasNeural)",
+    "DisplayName": "Thomas",
+    "LocalName": "Thomas",
+    "ShortName": "en-GB-ThomasNeural",
+    "Gender": "Male",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-GB, MiaNeural)",
+    "DisplayName": "Mia",
+    "LocalName": "Mia",
+    "ShortName": "en-GB-MiaNeural",
+    "Gender": "Female",
+    "Locale": "en-GB",
+    "LocaleName": "English (United Kingdom)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "Deprecated"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-HK, YanNeural)",
+    "DisplayName": "Yan",
+    "LocalName": "Yan",
+    "ShortName": "en-HK-YanNeural",
+    "Gender": "Female",
+    "Locale": "en-HK",
+    "LocaleName": "English (Hong Kong SAR)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-HK, SamNeural)",
+    "DisplayName": "Sam",
+    "LocalName": "Sam",
+    "ShortName": "en-HK-SamNeural",
+    "Gender": "Male",
+    "Locale": "en-HK",
+    "LocaleName": "English (Hong Kong SAR)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "140"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IE, EmilyNeural)",
+    "DisplayName": "Emily",
+    "LocalName": "Emily",
+    "ShortName": "en-IE-EmilyNeural",
+    "Gender": "Female",
+    "Locale": "en-IE",
+    "LocaleName": "English (Ireland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IE, ConnorNeural)",
+    "DisplayName": "Connor",
+    "LocalName": "Connor",
+    "ShortName": "en-IE-ConnorNeural",
+    "Gender": "Male",
+    "Locale": "en-IE",
+    "LocaleName": "English (Ireland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Light-Hearted",
+        "Whimsical",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "146"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, AaravNeural)",
+    "DisplayName": "Aarav",
+    "LocalName": "Aarav",
+    "ShortName": "en-IN-AaravNeural",
+    "Gender": "Male",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, AashiNeural)",
+    "DisplayName": "Aashi",
+    "LocalName": "Aashi",
+    "ShortName": "en-IN-AashiNeural",
+    "Gender": "Female",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, AartiNeural)",
+    "DisplayName": "Aarti",
+    "LocalName": "Aarti",
+    "ShortName": "en-IN-AartiNeural",
+    "Gender": "Female",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, ArjunNeural)",
+    "DisplayName": "Arjun",
+    "LocalName": "Arjun",
+    "ShortName": "en-IN-ArjunNeural",
+    "Gender": "Male",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, AnanyaNeural)",
+    "DisplayName": "Ananya",
+    "LocalName": "Ananya",
+    "ShortName": "en-IN-AnanyaNeural",
+    "Gender": "Female",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, KavyaNeural)",
+    "DisplayName": "Kavya",
+    "LocalName": "Kavya",
+    "ShortName": "en-IN-KavyaNeural",
+    "Gender": "Female",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, KunalNeural)",
+    "DisplayName": "Kunal",
+    "LocalName": "Kunal",
+    "ShortName": "en-IN-KunalNeural",
+    "Gender": "Male",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, NeerjaNeural)",
+    "DisplayName": "Neerja",
+    "LocalName": "Neerja",
+    "ShortName": "en-IN-NeerjaNeural",
+    "Gender": "Female",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "StyleList": [
+      "newscast",
+      "cheerful",
+      "empathetic"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, PrabhatNeural)",
+    "DisplayName": "Prabhat",
+    "LocalName": "Prabhat",
+    "ShortName": "en-IN-PrabhatNeural",
+    "Gender": "Male",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "129"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-IN, RehaanNeural)",
+    "DisplayName": "Rehaan",
+    "LocalName": "Rehaan",
+    "ShortName": "en-IN-RehaanNeural",
+    "Gender": "Male",
+    "Locale": "en-IN",
+    "LocaleName": "English (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-KE, AsiliaNeural)",
+    "DisplayName": "Asilia",
+    "LocalName": "Asilia",
+    "ShortName": "en-KE-AsiliaNeural",
+    "Gender": "Female",
+    "Locale": "en-KE",
+    "LocaleName": "English (Kenya)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-KE, ChilembaNeural)",
+    "DisplayName": "Chilemba",
+    "LocalName": "Chilemba",
+    "ShortName": "en-KE-ChilembaNeural",
+    "Gender": "Male",
+    "Locale": "en-KE",
+    "LocaleName": "English (Kenya)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "156"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-NG, EzinneNeural)",
+    "DisplayName": "Ezinne",
+    "LocalName": "Ezinne",
+    "ShortName": "en-NG-EzinneNeural",
+    "Gender": "Female",
+    "Locale": "en-NG",
+    "LocaleName": "English (Nigeria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-NG, AbeoNeural)",
+    "DisplayName": "Abeo",
+    "LocalName": "Abeo",
+    "ShortName": "en-NG-AbeoNeural",
+    "Gender": "Male",
+    "Locale": "en-NG",
+    "LocaleName": "English (Nigeria)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "153"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-NZ, MollyNeural)",
+    "DisplayName": "Molly",
+    "LocalName": "Molly",
+    "ShortName": "en-NZ-MollyNeural",
+    "Gender": "Female",
+    "Locale": "en-NZ",
+    "LocaleName": "English (New Zealand)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "132"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-NZ, MitchellNeural)",
+    "DisplayName": "Mitchell",
+    "LocalName": "Mitchell",
+    "ShortName": "en-NZ-MitchellNeural",
+    "Gender": "Male",
+    "Locale": "en-NZ",
+    "LocaleName": "English (New Zealand)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-PH, RosaNeural)",
+    "DisplayName": "Rosa",
+    "LocalName": "Rosa",
+    "ShortName": "en-PH-RosaNeural",
+    "Gender": "Female",
+    "Locale": "en-PH",
+    "LocaleName": "English (Philippines)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "137"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-PH, JamesNeural)",
+    "DisplayName": "James",
+    "LocalName": "James",
+    "ShortName": "en-PH-JamesNeural",
+    "Gender": "Male",
+    "Locale": "en-PH",
+    "LocaleName": "English (Philippines)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "147"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-SG, LunaNeural)",
+    "DisplayName": "Luna",
+    "LocalName": "Luna",
+    "ShortName": "en-SG-LunaNeural",
+    "Gender": "Female",
+    "Locale": "en-SG",
+    "LocaleName": "English (Singapore)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-SG, WayneNeural)",
+    "DisplayName": "Wayne",
+    "LocalName": "Wayne",
+    "ShortName": "en-SG-WayneNeural",
+    "Gender": "Male",
+    "Locale": "en-SG",
+    "LocaleName": "English (Singapore)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-TZ, ImaniNeural)",
+    "DisplayName": "Imani",
+    "LocalName": "Imani",
+    "ShortName": "en-TZ-ImaniNeural",
+    "Gender": "Female",
+    "Locale": "en-TZ",
+    "LocaleName": "English (Tanzania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-TZ, ElimuNeural)",
+    "DisplayName": "Elimu",
+    "LocalName": "Elimu",
+    "ShortName": "en-TZ-ElimuNeural",
+    "Gender": "Male",
+    "Locale": "en-TZ",
+    "LocaleName": "English (Tanzania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AvaMultilingualNeural)",
+    "DisplayName": "Ava Multilingual",
+    "LocalName": "Ava Multilingual",
+    "ShortName": "en-US-AvaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Pleasant",
+        "Friendly",
+        "Caring"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AndrewMultilingualNeural)",
+    "DisplayName": "Andrew Multilingual",
+    "LocalName": "Andrew Multilingual",
+    "ShortName": "en-US-AndrewMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "empathetic",
+      "relieved"
+    ],
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Advertisement"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Casual",
+        "Warm"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, EmmaMultilingualNeural)",
+    "DisplayName": "Emma Multilingual",
+    "LocalName": "Emma Multilingual",
+    "ShortName": "en-US-EmmaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "E-learning",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Light-Hearted",
+        "Casual"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AlloyTurboMultilingualNeural)",
+    "DisplayName": "Alloy Turbo Multilingual",
+    "LocalName": "Alloy Turbo Multilingual",
+    "ShortName": "en-US-AlloyTurboMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Versatile"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, EchoTurboMultilingualNeural)",
+    "DisplayName": "Echo Turbo Multilingual",
+    "LocalName": "Echo Turbo Multilingual",
+    "ShortName": "en-US-EchoTurboMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, FableTurboMultilingualNeural)",
+    "DisplayName": "Fable Turbo Multilingual",
+    "LocalName": "Fable Turbo Multilingual",
+    "ShortName": "en-US-FableTurboMultilingualNeural",
+    "Gender": "Neutral",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, OnyxTurboMultilingualNeural)",
+    "DisplayName": "Onyx Turbo Multilingual",
+    "LocalName": "Onyx Turbo Multilingual",
+    "ShortName": "en-US-OnyxTurboMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, NovaTurboMultilingualNeural)",
+    "DisplayName": "Nova Turbo Multilingual",
+    "LocalName": "Nova Turbo Multilingual",
+    "ShortName": "en-US-NovaTurboMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Resonant"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, ShimmerTurboMultilingualNeural)",
+    "DisplayName": "Shimmer Turbo Multilingual",
+    "LocalName": "Shimmer Turbo Multilingual",
+    "ShortName": "en-US-ShimmerTurboMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, BrianMultilingualNeural)",
+    "DisplayName": "Brian Multilingual",
+    "LocalName": "Brian Multilingual",
+    "ShortName": "en-US-BrianMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Podcast",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Calm",
+        "Approachable"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AvaNeural)",
+    "DisplayName": "Ava",
+    "LocalName": "Ava",
+    "ShortName": "en-US-AvaNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Documentary"
+      ],
+      "VoicePersonalities": [
+        "Pleasant",
+        "Caring",
+        "Friendly"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AndrewNeural)",
+    "DisplayName": "Andrew",
+    "LocalName": "Andrew",
+    "ShortName": "en-US-AndrewNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Advertisement"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Authentic",
+        "Warm"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, EmmaNeural)",
+    "DisplayName": "Emma",
+    "LocalName": "Emma",
+    "ShortName": "en-US-EmmaNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "E-learning",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Light-Hearted",
+        "Casual"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, BrianNeural)",
+    "DisplayName": "Brian",
+    "LocalName": "Brian",
+    "ShortName": "en-US-BrianNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Podcast",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Calm",
+        "Approachable"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, JennyNeural)",
+    "DisplayName": "Jenny",
+    "LocalName": "Jenny",
+    "ShortName": "en-US-JennyNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "assistant",
+      "chat",
+      "customerservice",
+      "newscast",
+      "angry",
+      "cheerful",
+      "sad",
+      "excited",
+      "friendly",
+      "terrified",
+      "shouting",
+      "unfriendly",
+      "whispering",
+      "hopeful"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Pleasant",
+        "Approachable"
+      ]
+    },
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, GuyNeural)",
+    "DisplayName": "Guy",
+    "LocalName": "Guy",
+    "ShortName": "en-US-GuyNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "newscast",
+      "angry",
+      "cheerful",
+      "sad",
+      "excited",
+      "friendly",
+      "terrified",
+      "shouting",
+      "unfriendly",
+      "whispering",
+      "hopeful"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Light-Hearted",
+        "Whimsical",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "215"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AriaNeural)",
+    "DisplayName": "Aria",
+    "LocalName": "Aria",
+    "ShortName": "en-US-AriaNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "chat",
+      "customerservice",
+      "narration-professional",
+      "newscast-casual",
+      "newscast-formal",
+      "cheerful",
+      "empathetic",
+      "angry",
+      "sad",
+      "excited",
+      "friendly",
+      "terrified",
+      "shouting",
+      "unfriendly",
+      "whispering",
+      "hopeful"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, DavisNeural)",
+    "DisplayName": "Davis",
+    "LocalName": "Davis",
+    "ShortName": "en-US-DavisNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "chat",
+      "angry",
+      "cheerful",
+      "excited",
+      "friendly",
+      "hopeful",
+      "sad",
+      "shouting",
+      "terrified",
+      "unfriendly",
+      "whispering"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "meditation"
+      ],
+      "VoicePersonalities": [
+        "Soothing",
+        "Calm",
+        "Smooth"
+      ]
+    },
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, JaneNeural)",
+    "DisplayName": "Jane",
+    "LocalName": "Jane",
+    "ShortName": "en-US-JaneNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "angry",
+      "cheerful",
+      "excited",
+      "friendly",
+      "hopeful",
+      "sad",
+      "shouting",
+      "terrified",
+      "unfriendly",
+      "whispering"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Meditation"
+      ],
+      "VoicePersonalities": [
+        "Serious",
+        "Approachable",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, JasonNeural)",
+    "DisplayName": "Jason",
+    "LocalName": "Jason",
+    "ShortName": "en-US-JasonNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "angry",
+      "cheerful",
+      "excited",
+      "friendly",
+      "hopeful",
+      "sad",
+      "shouting",
+      "terrified",
+      "unfriendly",
+      "whispering"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Gentle",
+        "Shy",
+        "Polite"
+      ]
+    },
+    "WordsPerMinute": "156"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, KaiNeural)",
+    "DisplayName": "Kai",
+    "LocalName": "Kai",
+    "ShortName": "en-US-KaiNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "conversation"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Pleasant",
+        "Bright",
+        "Clear",
+        "Friendly",
+        "Warm"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, LunaNeural)",
+    "DisplayName": "Luna",
+    "LocalName": "Luna",
+    "ShortName": "en-US-LunaNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "conversation"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Pleasant",
+        "Bright",
+        "Clear",
+        "Friendly",
+        "Warm"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, SaraNeural)",
+    "DisplayName": "Sara",
+    "LocalName": "Sara",
+    "ShortName": "en-US-SaraNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "angry",
+      "cheerful",
+      "excited",
+      "friendly",
+      "hopeful",
+      "sad",
+      "shouting",
+      "terrified",
+      "unfriendly",
+      "whispering"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "VoicePersonalities": [
+        "Sincere",
+        "Calm",
+        "Confident"
+      ]
+    },
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, TonyNeural)",
+    "DisplayName": "Tony",
+    "LocalName": "Tony",
+    "ShortName": "en-US-TonyNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "angry",
+      "cheerful",
+      "excited",
+      "friendly",
+      "hopeful",
+      "sad",
+      "shouting",
+      "terrified",
+      "unfriendly",
+      "whispering"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Gaming",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Thoughtful",
+        "Authentic",
+        "Sincere"
+      ]
+    },
+    "WordsPerMinute": "156"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, NancyNeural)",
+    "DisplayName": "Nancy",
+    "LocalName": "Nancy",
+    "ShortName": "en-US-NancyNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "StyleList": [
+      "angry",
+      "cheerful",
+      "excited",
+      "friendly",
+      "hopeful",
+      "sad",
+      "shouting",
+      "terrified",
+      "unfriendly",
+      "whispering"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Serious",
+        "Mature"
+      ]
+    },
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, CoraMultilingualNeural)",
+    "DisplayName": "Cora Multilingual",
+    "LocalName": "Cora Multilingual",
+    "ShortName": "en-US-CoraMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "E-learning",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Empathetic",
+        "Formal",
+        "Sincere"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, ChristopherMultilingualNeural)",
+    "DisplayName": "Christopher Multilingual",
+    "LocalName": "Christopher Multilingual",
+    "ShortName": "en-US-ChristopherMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Meditation",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Warm"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, BrandonMultilingualNeural)",
+    "DisplayName": "Brandon Multilingual",
+    "LocalName": "Brandon Multilingual",
+    "ShortName": "en-US-BrandonMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "E-learning",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Engaging",
+        "Authentic"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AmberNeural)",
+    "DisplayName": "Amber",
+    "LocalName": "Amber",
+    "ShortName": "en-US-AmberNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Whimsical",
+        "Upbeat",
+        "Light-Hearted"
+      ]
+    },
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AnaNeural)",
+    "DisplayName": "Ana",
+    "LocalName": "Ana",
+    "ShortName": "en-US-AnaNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful",
+        "Engaging"
+      ]
+    },
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, AshleyNeural)",
+    "DisplayName": "Ashley",
+    "LocalName": "Ashley",
+    "ShortName": "en-US-AshleyNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Gaming",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Approachable",
+        "Honest"
+      ]
+    },
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, BrandonNeural)",
+    "DisplayName": "Brandon",
+    "LocalName": "Brandon",
+    "ShortName": "en-US-BrandonNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Gaming",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Engaging",
+        "Authentic"
+      ]
+    },
+    "WordsPerMinute": "156"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, ChristopherNeural)",
+    "DisplayName": "Christopher",
+    "LocalName": "Christopher",
+    "ShortName": "en-US-ChristopherNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Meditation",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Warm"
+      ]
+    },
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, CoraNeural)",
+    "DisplayName": "Cora",
+    "LocalName": "Cora",
+    "ShortName": "en-US-CoraNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Meditation",
+        "Audiobook"
+      ],
+      "VoicePersonalities": [
+        "Empathetic",
+        "Formal",
+        "Sincere"
+      ]
+    },
+    "WordsPerMinute": "146"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, ElizabethNeural)",
+    "DisplayName": "Elizabeth",
+    "LocalName": "Elizabeth",
+    "ShortName": "en-US-ElizabethNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Authoritative",
+        "Formal",
+        "Serious"
+      ]
+    },
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, EricNeural)",
+    "DisplayName": "Eric",
+    "LocalName": "Eric",
+    "ShortName": "en-US-EricNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Sincere",
+        "Warm"
+      ]
+    },
+    "WordsPerMinute": "147"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, JacobNeural)",
+    "DisplayName": "Jacob",
+    "LocalName": "Jacob",
+    "ShortName": "en-US-JacobNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Formal",
+        "Confident"
+      ]
+    },
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, JennyMultilingualNeural)",
+    "DisplayName": "Jenny Multilingual",
+    "LocalName": "Jenny Multilingual",
+    "ShortName": "en-US-JennyMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "ar-EG",
+      "ar-SA",
+      "ca-ES",
+      "cs-CZ",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-HK",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "fi-FI",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "hi-IN",
+      "hu-HU",
+      "id-ID",
+      "it-IT",
+      "ja-JP",
+      "ko-KR",
+      "nb-NO",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "pt-BR",
+      "pt-PT",
+      "ru-RU",
+      "sv-SE",
+      "th-TH",
+      "tr-TR",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Sincere",
+        "Pleasant",
+        "Approachable"
+      ]
+    },
+    "WordsPerMinute": "190"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, MichelleNeural)",
+    "DisplayName": "Michelle",
+    "LocalName": "Michelle",
+    "ShortName": "en-US-MichelleNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Podcast",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Authentic",
+        "Warm"
+      ]
+    },
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, MonicaNeural)",
+    "DisplayName": "Monica",
+    "LocalName": "Monica",
+    "ShortName": "en-US-MonicaNeural",
+    "Gender": "Female",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Podcast",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Mature",
+        "Authentic",
+        "Warm"
+      ]
+    },
+    "WordsPerMinute": "145"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, RogerNeural)",
+    "DisplayName": "Roger",
+    "LocalName": "Roger",
+    "ShortName": "en-US-RogerNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Serious",
+        "Formal",
+        "Confident"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, RyanMultilingualNeural)",
+    "DisplayName": "Ryan Multilingual",
+    "LocalName": "Ryan Multilingual",
+    "ShortName": "en-US-RyanMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SecondaryLocaleList": [
+      "ar-EG",
+      "ar-SA",
+      "ca-ES",
+      "cs-CZ",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-HK",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "fi-FI",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "hi-IN",
+      "hu-HU",
+      "id-ID",
+      "it-IT",
+      "ja-JP",
+      "ko-KR",
+      "nb-NO",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "pt-BR",
+      "pt-PT",
+      "ru-RU",
+      "sv-SE",
+      "th-TH",
+      "tr-TR",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Professional",
+        "Authentic",
+        "Sincere"
+      ]
+    },
+    "WordsPerMinute": "190"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-US, SteffanNeural)",
+    "DisplayName": "Steffan",
+    "LocalName": "Steffan",
+    "ShortName": "en-US-SteffanNeural",
+    "Gender": "Male",
+    "Locale": "en-US",
+    "LocaleName": "English (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Mature",
+        "Authentic",
+        "Warm"
+      ]
+    },
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-ZA, LeahNeural)",
+    "DisplayName": "Leah",
+    "LocalName": "Leah",
+    "ShortName": "en-ZA-LeahNeural",
+    "Gender": "Female",
+    "Locale": "en-ZA",
+    "LocaleName": "English (South Africa)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (en-ZA, LukeNeural)",
+    "DisplayName": "Luke",
+    "LocalName": "Luke",
+    "ShortName": "en-ZA-LukeNeural",
+    "Gender": "Male",
+    "Locale": "en-ZA",
+    "LocaleName": "English (South Africa)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "168"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-AR, ElenaNeural)",
+    "DisplayName": "Elena",
+    "LocalName": "Elena",
+    "ShortName": "es-AR-ElenaNeural",
+    "Gender": "Female",
+    "Locale": "es-AR",
+    "LocaleName": "Spanish (Argentina)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-AR, TomasNeural)",
+    "DisplayName": "Tomas",
+    "LocalName": "Tomas",
+    "ShortName": "es-AR-TomasNeural",
+    "Gender": "Male",
+    "Locale": "es-AR",
+    "LocaleName": "Spanish (Argentina)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "158"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-BO, SofiaNeural)",
+    "DisplayName": "Sofia",
+    "LocalName": "Sofia",
+    "ShortName": "es-BO-SofiaNeural",
+    "Gender": "Female",
+    "Locale": "es-BO",
+    "LocaleName": "Spanish (Bolivia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "159"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-BO, MarceloNeural)",
+    "DisplayName": "Marcelo",
+    "LocalName": "Marcelo",
+    "ShortName": "es-BO-MarceloNeural",
+    "Gender": "Male",
+    "Locale": "es-BO",
+    "LocaleName": "Spanish (Bolivia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CL, CatalinaNeural)",
+    "DisplayName": "Catalina",
+    "LocalName": "Catalina",
+    "ShortName": "es-CL-CatalinaNeural",
+    "Gender": "Female",
+    "Locale": "es-CL",
+    "LocaleName": "Spanish (Chile)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "295"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CL, LorenzoNeural)",
+    "DisplayName": "Lorenzo",
+    "LocalName": "Lorenzo",
+    "ShortName": "es-CL-LorenzoNeural",
+    "Gender": "Male",
+    "Locale": "es-CL",
+    "LocaleName": "Spanish (Chile)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "318"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CO, SalomeNeural)",
+    "DisplayName": "Salome",
+    "LocalName": "Salome",
+    "ShortName": "es-CO-SalomeNeural",
+    "Gender": "Female",
+    "Locale": "es-CO",
+    "LocaleName": "Spanish (Colombia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CO, GonzaloNeural)",
+    "DisplayName": "Gonzalo",
+    "LocalName": "Gonzalo",
+    "ShortName": "es-CO-GonzaloNeural",
+    "Gender": "Male",
+    "Locale": "es-CO",
+    "LocaleName": "Spanish (Colombia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "161"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CR, MariaNeural)",
+    "DisplayName": "Maria",
+    "LocalName": "María",
+    "ShortName": "es-CR-MariaNeural",
+    "Gender": "Female",
+    "Locale": "es-CR",
+    "LocaleName": "Spanish (Costa Rica)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CR, JuanNeural)",
+    "DisplayName": "Juan",
+    "LocalName": "Juan",
+    "ShortName": "es-CR-JuanNeural",
+    "Gender": "Male",
+    "Locale": "es-CR",
+    "LocaleName": "Spanish (Costa Rica)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CU, BelkysNeural)",
+    "DisplayName": "Belkys",
+    "LocalName": "Belkys",
+    "ShortName": "es-CU-BelkysNeural",
+    "Gender": "Female",
+    "Locale": "es-CU",
+    "LocaleName": "Spanish (Cuba)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-CU, ManuelNeural)",
+    "DisplayName": "Manuel",
+    "LocalName": "Manuel",
+    "ShortName": "es-CU-ManuelNeural",
+    "Gender": "Male",
+    "Locale": "es-CU",
+    "LocaleName": "Spanish (Cuba)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "137"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-DO, RamonaNeural)",
+    "DisplayName": "Ramona",
+    "LocalName": "Ramona",
+    "ShortName": "es-DO-RamonaNeural",
+    "Gender": "Female",
+    "Locale": "es-DO",
+    "LocaleName": "Spanish (Dominican Republic)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "130"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-DO, EmilioNeural)",
+    "DisplayName": "Emilio",
+    "LocalName": "Emilio",
+    "ShortName": "es-DO-EmilioNeural",
+    "Gender": "Male",
+    "Locale": "es-DO",
+    "LocaleName": "Spanish (Dominican Republic)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-EC, AndreaNeural)",
+    "DisplayName": "Andrea",
+    "LocalName": "Andrea",
+    "ShortName": "es-EC-AndreaNeural",
+    "Gender": "Female",
+    "Locale": "es-EC",
+    "LocaleName": "Spanish (Ecuador)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-EC, LuisNeural)",
+    "DisplayName": "Luis",
+    "LocalName": "Luis",
+    "ShortName": "es-EC-LuisNeural",
+    "Gender": "Male",
+    "Locale": "es-EC",
+    "LocaleName": "Spanish (Ecuador)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, ElviraNeural)",
+    "DisplayName": "Elvira",
+    "LocalName": "Elvira",
+    "ShortName": "es-ES-ElviraNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, AlvaroNeural)",
+    "DisplayName": "Alvaro",
+    "LocalName": "Álvaro",
+    "ShortName": "es-ES-AlvaroNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Animated"
+      ]
+    },
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, ArabellaMultilingualNeural)",
+    "DisplayName": "Arabella Multilingual",
+    "LocalName": "Arabella Multilingual",
+    "ShortName": "es-ES-ArabellaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Friendly",
+        "Casual",
+        "Warm",
+        "Pleasant"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, IsidoraMultilingualNeural)",
+    "DisplayName": "Isidora Multilingual",
+    "LocalName": "Isidora Multilingual",
+    "ShortName": "es-ES-IsidoraMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Friendly",
+        "Warm",
+        "Casual"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, TristanMultilingualNeural)",
+    "DisplayName": "Tristan Multilingual",
+    "LocalName": "Tristan Multilingual",
+    "ShortName": "es-ES-TristanMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Formal",
+        "Clear",
+        "Trusthworthy"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, XimenaMultilingualNeural)",
+    "DisplayName": "Ximena Multilingual",
+    "LocalName": "Ximena Multilingual",
+    "ShortName": "es-ES-XimenaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Formal",
+        "Serious",
+        "Upbeat"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, AbrilNeural)",
+    "DisplayName": "Abril",
+    "LocalName": "Abril",
+    "ShortName": "es-ES-AbrilNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "146"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, ArnauNeural)",
+    "DisplayName": "Arnau",
+    "LocalName": "Arnau",
+    "ShortName": "es-ES-ArnauNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, DarioNeural)",
+    "DisplayName": "Dario",
+    "LocalName": "Dario",
+    "ShortName": "es-ES-DarioNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "164"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, EliasNeural)",
+    "DisplayName": "Elias",
+    "LocalName": "Elias",
+    "ShortName": "es-ES-EliasNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, EstrellaNeural)",
+    "DisplayName": "Estrella",
+    "LocalName": "Estrella",
+    "ShortName": "es-ES-EstrellaNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, IreneNeural)",
+    "DisplayName": "Irene",
+    "LocalName": "Irene",
+    "ShortName": "es-ES-IreneNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, LaiaNeural)",
+    "DisplayName": "Laia",
+    "LocalName": "Laia",
+    "ShortName": "es-ES-LaiaNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, LiaNeural)",
+    "DisplayName": "Lia",
+    "LocalName": "Lia",
+    "ShortName": "es-ES-LiaNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, NilNeural)",
+    "DisplayName": "Nil",
+    "LocalName": "Nil",
+    "ShortName": "es-ES-NilNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, SaulNeural)",
+    "DisplayName": "Saul",
+    "LocalName": "Saul",
+    "ShortName": "es-ES-SaulNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, TeoNeural)",
+    "DisplayName": "Teo",
+    "LocalName": "Teo",
+    "ShortName": "es-ES-TeoNeural",
+    "Gender": "Male",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, TrianaNeural)",
+    "DisplayName": "Triana",
+    "LocalName": "Triana",
+    "ShortName": "es-ES-TrianaNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, VeraNeural)",
+    "DisplayName": "Vera",
+    "LocalName": "Vera",
+    "ShortName": "es-ES-VeraNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-ES, XimenaNeural)",
+    "DisplayName": "Ximena",
+    "LocalName": "Ximena",
+    "ShortName": "es-ES-XimenaNeural",
+    "Gender": "Female",
+    "Locale": "es-ES",
+    "LocaleName": "Spanish (Spain)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Cheerful"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-GQ, TeresaNeural)",
+    "DisplayName": "Teresa",
+    "LocalName": "Teresa",
+    "ShortName": "es-GQ-TeresaNeural",
+    "Gender": "Female",
+    "Locale": "es-GQ",
+    "LocaleName": "Spanish (Equatorial Guinea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-GQ, JavierNeural)",
+    "DisplayName": "Javier",
+    "LocalName": "Javier",
+    "ShortName": "es-GQ-JavierNeural",
+    "Gender": "Male",
+    "Locale": "es-GQ",
+    "LocaleName": "Spanish (Equatorial Guinea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "129"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-GT, MartaNeural)",
+    "DisplayName": "Marta",
+    "LocalName": "Marta",
+    "ShortName": "es-GT-MartaNeural",
+    "Gender": "Female",
+    "Locale": "es-GT",
+    "LocaleName": "Spanish (Guatemala)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "159"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-GT, AndresNeural)",
+    "DisplayName": "Andres",
+    "LocalName": "Andrés",
+    "ShortName": "es-GT-AndresNeural",
+    "Gender": "Male",
+    "Locale": "es-GT",
+    "LocaleName": "Spanish (Guatemala)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-HN, KarlaNeural)",
+    "DisplayName": "Karla",
+    "LocalName": "Karla",
+    "ShortName": "es-HN-KarlaNeural",
+    "Gender": "Female",
+    "Locale": "es-HN",
+    "LocaleName": "Spanish (Honduras)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "137"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-HN, CarlosNeural)",
+    "DisplayName": "Carlos",
+    "LocalName": "Carlos",
+    "ShortName": "es-HN-CarlosNeural",
+    "Gender": "Male",
+    "Locale": "es-HN",
+    "LocaleName": "Spanish (Honduras)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, DaliaNeural)",
+    "DisplayName": "Dalia",
+    "LocalName": "Dalia",
+    "ShortName": "es-MX-DaliaNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "145"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, JorgeNeural)",
+    "DisplayName": "Jorge",
+    "LocalName": "Jorge",
+    "ShortName": "es-MX-JorgeNeural",
+    "Gender": "Male",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "StyleList": [
+      "cheerful",
+      "chat"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Deep",
+        "Confident"
+      ]
+    },
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, BeatrizNeural)",
+    "DisplayName": "Beatriz",
+    "LocalName": "Beatriz",
+    "ShortName": "es-MX-BeatrizNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, CandelaNeural)",
+    "DisplayName": "Candela",
+    "LocalName": "Candela",
+    "ShortName": "es-MX-CandelaNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, CarlotaNeural)",
+    "DisplayName": "Carlota",
+    "LocalName": "Carlota",
+    "ShortName": "es-MX-CarlotaNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "145"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, CecilioNeural)",
+    "DisplayName": "Cecilio",
+    "LocalName": "Cecilio",
+    "ShortName": "es-MX-CecilioNeural",
+    "Gender": "Male",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, GerardoNeural)",
+    "DisplayName": "Gerardo",
+    "LocalName": "Gerardo",
+    "ShortName": "es-MX-GerardoNeural",
+    "Gender": "Male",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, LarissaNeural)",
+    "DisplayName": "Larissa",
+    "LocalName": "Larissa",
+    "ShortName": "es-MX-LarissaNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "151"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, LibertoNeural)",
+    "DisplayName": "Liberto",
+    "LocalName": "Liberto",
+    "ShortName": "es-MX-LibertoNeural",
+    "Gender": "Male",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, LucianoNeural)",
+    "DisplayName": "Luciano",
+    "LocalName": "Luciano",
+    "ShortName": "es-MX-LucianoNeural",
+    "Gender": "Male",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "139"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, MarinaNeural)",
+    "DisplayName": "Marina",
+    "LocalName": "Marina",
+    "ShortName": "es-MX-MarinaNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "136"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, NuriaNeural)",
+    "DisplayName": "Nuria",
+    "LocalName": "Nuria",
+    "ShortName": "es-MX-NuriaNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, PelayoNeural)",
+    "DisplayName": "Pelayo",
+    "LocalName": "Pelayo",
+    "ShortName": "es-MX-PelayoNeural",
+    "Gender": "Male",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, RenataNeural)",
+    "DisplayName": "Renata",
+    "LocalName": "Renata",
+    "ShortName": "es-MX-RenataNeural",
+    "Gender": "Female",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "153"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-MX, YagoNeural)",
+    "DisplayName": "Yago",
+    "LocalName": "Yago",
+    "ShortName": "es-MX-YagoNeural",
+    "Gender": "Male",
+    "Locale": "es-MX",
+    "LocaleName": "Spanish (Mexico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-NI, YolandaNeural)",
+    "DisplayName": "Yolanda",
+    "LocalName": "Yolanda",
+    "ShortName": "es-NI-YolandaNeural",
+    "Gender": "Female",
+    "Locale": "es-NI",
+    "LocaleName": "Spanish (Nicaragua)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "130"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-NI, FedericoNeural)",
+    "DisplayName": "Federico",
+    "LocalName": "Federico",
+    "ShortName": "es-NI-FedericoNeural",
+    "Gender": "Male",
+    "Locale": "es-NI",
+    "LocaleName": "Spanish (Nicaragua)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PA, MargaritaNeural)",
+    "DisplayName": "Margarita",
+    "LocalName": "Margarita",
+    "ShortName": "es-PA-MargaritaNeural",
+    "Gender": "Female",
+    "Locale": "es-PA",
+    "LocaleName": "Spanish (Panama)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PA, RobertoNeural)",
+    "DisplayName": "Roberto",
+    "LocalName": "Roberto",
+    "ShortName": "es-PA-RobertoNeural",
+    "Gender": "Male",
+    "Locale": "es-PA",
+    "LocaleName": "Spanish (Panama)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PE, CamilaNeural)",
+    "DisplayName": "Camila",
+    "LocalName": "Camila",
+    "ShortName": "es-PE-CamilaNeural",
+    "Gender": "Female",
+    "Locale": "es-PE",
+    "LocaleName": "Spanish (Peru)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "159"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PE, AlexNeural)",
+    "DisplayName": "Alex",
+    "LocalName": "Alex",
+    "ShortName": "es-PE-AlexNeural",
+    "Gender": "Male",
+    "Locale": "es-PE",
+    "LocaleName": "Spanish (Peru)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PR, KarinaNeural)",
+    "DisplayName": "Karina",
+    "LocalName": "Karina",
+    "ShortName": "es-PR-KarinaNeural",
+    "Gender": "Female",
+    "Locale": "es-PR",
+    "LocaleName": "Spanish (Puerto Rico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "130"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PR, VictorNeural)",
+    "DisplayName": "Victor",
+    "LocalName": "Víctor",
+    "ShortName": "es-PR-VictorNeural",
+    "Gender": "Male",
+    "Locale": "es-PR",
+    "LocaleName": "Spanish (Puerto Rico)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PY, TaniaNeural)",
+    "DisplayName": "Tania",
+    "LocalName": "Tania",
+    "ShortName": "es-PY-TaniaNeural",
+    "Gender": "Female",
+    "Locale": "es-PY",
+    "LocaleName": "Spanish (Paraguay)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "151"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-PY, MarioNeural)",
+    "DisplayName": "Mario",
+    "LocalName": "Mario",
+    "ShortName": "es-PY-MarioNeural",
+    "Gender": "Male",
+    "Locale": "es-PY",
+    "LocaleName": "Spanish (Paraguay)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "168"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-SV, LorenaNeural)",
+    "DisplayName": "Lorena",
+    "LocalName": "Lorena",
+    "ShortName": "es-SV-LorenaNeural",
+    "Gender": "Female",
+    "Locale": "es-SV",
+    "LocaleName": "Spanish (El Salvador)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "159"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-SV, RodrigoNeural)",
+    "DisplayName": "Rodrigo",
+    "LocalName": "Rodrigo",
+    "ShortName": "es-SV-RodrigoNeural",
+    "Gender": "Male",
+    "Locale": "es-SV",
+    "LocaleName": "Spanish (El Salvador)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-US, PalomaNeural)",
+    "DisplayName": "Paloma",
+    "LocalName": "Paloma",
+    "ShortName": "es-US-PalomaNeural",
+    "Gender": "Female",
+    "Locale": "es-US",
+    "LocaleName": "Spanish (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-US, AlonsoNeural)",
+    "DisplayName": "Alonso",
+    "LocalName": "Alonso",
+    "ShortName": "es-US-AlonsoNeural",
+    "Gender": "Male",
+    "Locale": "es-US",
+    "LocaleName": "Spanish (United States)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-UY, ValentinaNeural)",
+    "DisplayName": "Valentina",
+    "LocalName": "Valentina",
+    "ShortName": "es-UY-ValentinaNeural",
+    "Gender": "Female",
+    "Locale": "es-UY",
+    "LocaleName": "Spanish (Uruguay)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-UY, MateoNeural)",
+    "DisplayName": "Mateo",
+    "LocalName": "Mateo",
+    "ShortName": "es-UY-MateoNeural",
+    "Gender": "Male",
+    "Locale": "es-UY",
+    "LocaleName": "Spanish (Uruguay)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "158"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-VE, PaolaNeural)",
+    "DisplayName": "Paola",
+    "LocalName": "Paola",
+    "ShortName": "es-VE-PaolaNeural",
+    "Gender": "Female",
+    "Locale": "es-VE",
+    "LocaleName": "Spanish (Venezuela)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "130"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (es-VE, SebastianNeural)",
+    "DisplayName": "Sebastian",
+    "LocalName": "Sebastián",
+    "ShortName": "es-VE-SebastianNeural",
+    "Gender": "Male",
+    "Locale": "es-VE",
+    "LocaleName": "Spanish (Venezuela)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (et-EE, AnuNeural)",
+    "DisplayName": "Anu",
+    "LocalName": "Anu",
+    "ShortName": "et-EE-AnuNeural",
+    "Gender": "Female",
+    "Locale": "et-EE",
+    "LocaleName": "Estonian (Estonia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (et-EE, KertNeural)",
+    "DisplayName": "Kert",
+    "LocalName": "Kert",
+    "ShortName": "et-EE-KertNeural",
+    "Gender": "Male",
+    "Locale": "et-EE",
+    "LocaleName": "Estonian (Estonia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (eu-ES, AinhoaNeural)",
+    "DisplayName": "Ainhoa",
+    "LocalName": "Ainhoa",
+    "ShortName": "eu-ES-AinhoaNeural",
+    "Gender": "Female",
+    "Locale": "eu-ES",
+    "LocaleName": "Basque",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "102"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (eu-ES, AnderNeural)",
+    "DisplayName": "Ander",
+    "LocalName": "Ander",
+    "ShortName": "eu-ES-AnderNeural",
+    "Gender": "Male",
+    "Locale": "eu-ES",
+    "LocaleName": "Basque",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "102"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fa-IR, DilaraNeural)",
+    "DisplayName": "Dilara",
+    "LocalName": "دلارا",
+    "ShortName": "fa-IR-DilaraNeural",
+    "Gender": "Female",
+    "Locale": "fa-IR",
+    "LocaleName": "Persian (Iran)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fa-IR, FaridNeural)",
+    "DisplayName": "Farid",
+    "LocalName": "فرید",
+    "ShortName": "fa-IR-FaridNeural",
+    "Gender": "Male",
+    "Locale": "fa-IR",
+    "LocaleName": "Persian (Iran)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fi-FI, SelmaNeural)",
+    "DisplayName": "Selma",
+    "LocalName": "Selma",
+    "ShortName": "fi-FI-SelmaNeural",
+    "Gender": "Female",
+    "Locale": "fi-FI",
+    "LocaleName": "Finnish (Finland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "91"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fi-FI, HarriNeural)",
+    "DisplayName": "Harri",
+    "LocalName": "Harri",
+    "ShortName": "fi-FI-HarriNeural",
+    "Gender": "Male",
+    "Locale": "fi-FI",
+    "LocaleName": "Finnish (Finland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "97"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fi-FI, NooraNeural)",
+    "DisplayName": "Noora",
+    "LocalName": "Noora",
+    "ShortName": "fi-FI-NooraNeural",
+    "Gender": "Female",
+    "Locale": "fi-FI",
+    "LocaleName": "Finnish (Finland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "96"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fil-PH, BlessicaNeural)",
+    "DisplayName": "Blessica",
+    "LocalName": "Blessica",
+    "ShortName": "fil-PH-BlessicaNeural",
+    "Gender": "Female",
+    "Locale": "fil-PH",
+    "LocaleName": "Filipino (Philippines)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "140"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fil-PH, AngeloNeural)",
+    "DisplayName": "Angelo",
+    "LocalName": "Angelo",
+    "ShortName": "fil-PH-AngeloNeural",
+    "Gender": "Male",
+    "Locale": "fil-PH",
+    "LocaleName": "Filipino (Philippines)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-BE, CharlineNeural)",
+    "DisplayName": "Charline",
+    "LocalName": "Charline",
+    "ShortName": "fr-BE-CharlineNeural",
+    "Gender": "Female",
+    "Locale": "fr-BE",
+    "LocaleName": "French (Belgium)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-BE, GerardNeural)",
+    "DisplayName": "Gerard",
+    "LocalName": "Gerard",
+    "ShortName": "fr-BE-GerardNeural",
+    "Gender": "Male",
+    "Locale": "fr-BE",
+    "LocaleName": "French (Belgium)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "172"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-CA, SylvieNeural)",
+    "DisplayName": "Sylvie",
+    "LocalName": "Sylvie",
+    "ShortName": "fr-CA-SylvieNeural",
+    "Gender": "Female",
+    "Locale": "fr-CA",
+    "LocaleName": "French (Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-CA, JeanNeural)",
+    "DisplayName": "Jean",
+    "LocalName": "Jean",
+    "ShortName": "fr-CA-JeanNeural",
+    "Gender": "Male",
+    "Locale": "fr-CA",
+    "LocaleName": "French (Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-CA, AntoineNeural)",
+    "DisplayName": "Antoine",
+    "LocalName": "Antoine",
+    "ShortName": "fr-CA-AntoineNeural",
+    "Gender": "Male",
+    "Locale": "fr-CA",
+    "LocaleName": "French (Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "159"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-CA, ThierryNeural)",
+    "DisplayName": "Thierry",
+    "LocalName": "Thierry",
+    "ShortName": "fr-CA-ThierryNeural",
+    "Gender": "Male",
+    "Locale": "fr-CA",
+    "LocaleName": "French (Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Engaging",
+        "Caring"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-CH, ArianeNeural)",
+    "DisplayName": "Ariane",
+    "LocalName": "Ariane",
+    "ShortName": "fr-CH-ArianeNeural",
+    "Gender": "Female",
+    "Locale": "fr-CH",
+    "LocaleName": "French (Switzerland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "158"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-CH, FabriceNeural)",
+    "DisplayName": "Fabrice",
+    "LocalName": "Fabrice",
+    "ShortName": "fr-CH-FabriceNeural",
+    "Gender": "Male",
+    "Locale": "fr-CH",
+    "LocaleName": "French (Switzerland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "172"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, DeniseNeural)",
+    "DisplayName": "Denise",
+    "LocalName": "Denise",
+    "ShortName": "fr-FR-DeniseNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "StyleList": [
+      "cheerful",
+      "sad"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Engaging"
+      ]
+    },
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, HenriNeural)",
+    "DisplayName": "Henri",
+    "LocalName": "Henri",
+    "ShortName": "fr-FR-HenriNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "StyleList": [
+      "cheerful",
+      "sad"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Strong",
+        "Calm"
+      ]
+    },
+    "WordsPerMinute": "165"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, VivienneMultilingualNeural)",
+    "DisplayName": "Vivienne Multilingual",
+    "LocalName": "Vivienne Multilingue",
+    "ShortName": "fr-FR-VivienneMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Advertisement"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Casual"
+      ]
+    },
+    "WordsPerMinute": "190"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, RemyMultilingualNeural)",
+    "DisplayName": "Remy Multilingual",
+    "LocalName": "Rémy Multilingue",
+    "ShortName": "fr-FR-RemyMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "190"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, LucienMultilingualNeural)",
+    "DisplayName": "Lucien Multilingual",
+    "LocalName": "Lucien Multilingual",
+    "ShortName": "fr-FR-LucienMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Advertisement"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Formal",
+        "Confident"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, AlainNeural)",
+    "DisplayName": "Alain",
+    "LocalName": "Alain",
+    "ShortName": "fr-FR-AlainNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "165"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, BrigitteNeural)",
+    "DisplayName": "Brigitte",
+    "LocalName": "Brigitte",
+    "ShortName": "fr-FR-BrigitteNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "153"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, CelesteNeural)",
+    "DisplayName": "Celeste",
+    "LocalName": "Celeste",
+    "ShortName": "fr-FR-CelesteNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, ClaudeNeural)",
+    "DisplayName": "Claude",
+    "LocalName": "Claude",
+    "ShortName": "fr-FR-ClaudeNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, CoralieNeural)",
+    "DisplayName": "Coralie",
+    "LocalName": "Coralie",
+    "ShortName": "fr-FR-CoralieNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, EloiseNeural)",
+    "DisplayName": "Eloise",
+    "LocalName": "Eloise",
+    "ShortName": "fr-FR-EloiseNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "150"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, JacquelineNeural)",
+    "DisplayName": "Jacqueline",
+    "LocalName": "Jacqueline",
+    "ShortName": "fr-FR-JacquelineNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, JeromeNeural)",
+    "DisplayName": "Jerome",
+    "LocalName": "Jerome",
+    "ShortName": "fr-FR-JeromeNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "165"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, JosephineNeural)",
+    "DisplayName": "Josephine",
+    "LocalName": "Josephine",
+    "ShortName": "fr-FR-JosephineNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, MauriceNeural)",
+    "DisplayName": "Maurice",
+    "LocalName": "Maurice",
+    "ShortName": "fr-FR-MauriceNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "162"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, YvesNeural)",
+    "DisplayName": "Yves",
+    "LocalName": "Yves",
+    "ShortName": "fr-FR-YvesNeural",
+    "Gender": "Male",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "162"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (fr-FR, YvetteNeural)",
+    "DisplayName": "Yvette",
+    "LocalName": "Yvette",
+    "ShortName": "fr-FR-YvetteNeural",
+    "Gender": "Female",
+    "Locale": "fr-FR",
+    "LocaleName": "French (France)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "156"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ga-IE, OrlaNeural)",
+    "DisplayName": "Orla",
+    "LocalName": "Orla",
+    "ShortName": "ga-IE-OrlaNeural",
+    "Gender": "Female",
+    "Locale": "ga-IE",
+    "LocaleName": "Irish (Ireland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "139"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ga-IE, ColmNeural)",
+    "DisplayName": "Colm",
+    "LocalName": "Colm",
+    "ShortName": "ga-IE-ColmNeural",
+    "Gender": "Male",
+    "Locale": "ga-IE",
+    "LocaleName": "Irish (Ireland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (gl-ES, SabelaNeural)",
+    "DisplayName": "Sabela",
+    "LocalName": "Sabela",
+    "ShortName": "gl-ES-SabelaNeural",
+    "Gender": "Female",
+    "Locale": "gl-ES",
+    "LocaleName": "Galician",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (gl-ES, RoiNeural)",
+    "DisplayName": "Roi",
+    "LocalName": "Roi",
+    "ShortName": "gl-ES-RoiNeural",
+    "Gender": "Male",
+    "Locale": "gl-ES",
+    "LocaleName": "Galician",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (gu-IN, DhwaniNeural)",
+    "DisplayName": "Dhwani",
+    "LocalName": "ધ્વની",
+    "ShortName": "gu-IN-DhwaniNeural",
+    "Gender": "Female",
+    "Locale": "gu-IN",
+    "LocaleName": "Gujarati (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "89"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (gu-IN, NiranjanNeural)",
+    "DisplayName": "Niranjan",
+    "LocalName": "નિરંજન",
+    "ShortName": "gu-IN-NiranjanNeural",
+    "Gender": "Male",
+    "Locale": "gu-IN",
+    "LocaleName": "Gujarati (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "107"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (he-IL, HilaNeural)",
+    "DisplayName": "Hila",
+    "LocalName": "הילה",
+    "ShortName": "he-IL-HilaNeural",
+    "Gender": "Female",
+    "Locale": "he-IL",
+    "LocaleName": "Hebrew (Israel)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (he-IL, AvriNeural)",
+    "DisplayName": "Avri",
+    "LocalName": "אברי",
+    "ShortName": "he-IL-AvriNeural",
+    "Gender": "Male",
+    "Locale": "he-IL",
+    "LocaleName": "Hebrew (Israel)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "106"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, AaravNeural)",
+    "DisplayName": "Aarav",
+    "LocalName": "आरव ",
+    "ShortName": "hi-IN-AaravNeural",
+    "Gender": "Male",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, AnanyaNeural)",
+    "DisplayName": "Ananya",
+    "LocalName": "अनन्या",
+    "ShortName": "hi-IN-AnanyaNeural",
+    "Gender": "Female",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, AartiNeural)",
+    "DisplayName": "Aarti",
+    "LocalName": "आरती",
+    "ShortName": "hi-IN-AartiNeural",
+    "Gender": "Female",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, ArjunNeural)",
+    "DisplayName": "Arjun",
+    "LocalName": "अर्जुन",
+    "ShortName": "hi-IN-ArjunNeural",
+    "Gender": "Male",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, KavyaNeural)",
+    "DisplayName": "Kavya",
+    "LocalName": "काव्या",
+    "ShortName": "hi-IN-KavyaNeural",
+    "Gender": "Female",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, KunalNeural)",
+    "DisplayName": "Kunal",
+    "LocalName": "कुनाल ",
+    "ShortName": "hi-IN-KunalNeural",
+    "Gender": "Male",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, RehaanNeural)",
+    "DisplayName": "Rehaan",
+    "LocalName": "रेहान",
+    "ShortName": "hi-IN-RehaanNeural",
+    "Gender": "Male",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, SwaraNeural)",
+    "DisplayName": "Swara",
+    "LocalName": "स्वरा",
+    "ShortName": "hi-IN-SwaraNeural",
+    "Gender": "Female",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "StyleList": [
+      "newscast",
+      "cheerful",
+      "empathetic"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hi-IN, MadhurNeural)",
+    "DisplayName": "Madhur",
+    "LocalName": "मधुर",
+    "ShortName": "hi-IN-MadhurNeural",
+    "Gender": "Male",
+    "Locale": "hi-IN",
+    "LocaleName": "Hindi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hr-HR, GabrijelaNeural)",
+    "DisplayName": "Gabrijela",
+    "LocalName": "Gabrijela",
+    "ShortName": "hr-HR-GabrijelaNeural",
+    "Gender": "Female",
+    "Locale": "hr-HR",
+    "LocaleName": "Croatian (Croatia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "124"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hr-HR, SreckoNeural)",
+    "DisplayName": "Srecko",
+    "LocalName": "Srećko",
+    "ShortName": "hr-HR-SreckoNeural",
+    "Gender": "Male",
+    "Locale": "hr-HR",
+    "LocaleName": "Croatian (Croatia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Whimsical",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "133"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hu-HU, NoemiNeural)",
+    "DisplayName": "Noemi",
+    "LocalName": "Noémi",
+    "ShortName": "hu-HU-NoemiNeural",
+    "Gender": "Female",
+    "Locale": "hu-HU",
+    "LocaleName": "Hungarian (Hungary)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "110"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hu-HU, TamasNeural)",
+    "DisplayName": "Tamas",
+    "LocalName": "Tamás",
+    "ShortName": "hu-HU-TamasNeural",
+    "Gender": "Male",
+    "Locale": "hu-HU",
+    "LocaleName": "Hungarian (Hungary)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Whimsical",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "124"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hy-AM, AnahitNeural)",
+    "DisplayName": "Anahit",
+    "LocalName": "Անահիտ",
+    "ShortName": "hy-AM-AnahitNeural",
+    "Gender": "Female",
+    "Locale": "hy-AM",
+    "LocaleName": "Armenian (Armenia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "112"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (hy-AM, HaykNeural)",
+    "DisplayName": "Hayk",
+    "LocalName": "Հայկ",
+    "ShortName": "hy-AM-HaykNeural",
+    "Gender": "Male",
+    "Locale": "hy-AM",
+    "LocaleName": "Armenian (Armenia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "112"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (id-ID, GadisNeural)",
+    "DisplayName": "Gadis",
+    "LocalName": "Gadis",
+    "ShortName": "id-ID-GadisNeural",
+    "Gender": "Female",
+    "Locale": "id-ID",
+    "LocaleName": "Indonesian (Indonesia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "111"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (id-ID, ArdiNeural)",
+    "DisplayName": "Ardi",
+    "LocalName": "Ardi",
+    "ShortName": "id-ID-ArdiNeural",
+    "Gender": "Male",
+    "Locale": "id-ID",
+    "LocaleName": "Indonesian (Indonesia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "124"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (is-IS, GudrunNeural)",
+    "DisplayName": "Gudrun",
+    "LocalName": "Guðrún",
+    "ShortName": "is-IS-GudrunNeural",
+    "Gender": "Female",
+    "Locale": "is-IS",
+    "LocaleName": "Icelandic (Iceland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (is-IS, GunnarNeural)",
+    "DisplayName": "Gunnar",
+    "LocalName": "Gunnar",
+    "ShortName": "is-IS-GunnarNeural",
+    "Gender": "Male",
+    "Locale": "is-IS",
+    "LocaleName": "Icelandic (Iceland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, ElsaNeural)",
+    "DisplayName": "Elsa",
+    "LocalName": "Elsa",
+    "ShortName": "it-IT-ElsaNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Crisp"
+      ]
+    },
+    "WordsPerMinute": "148"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, IsabellaNeural)",
+    "DisplayName": "Isabella",
+    "LocalName": "Isabella",
+    "ShortName": "it-IT-IsabellaNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "StyleList": [
+      "cheerful",
+      "chat"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Upbeat",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, DiegoNeural)",
+    "DisplayName": "Diego",
+    "LocalName": "Diego",
+    "ShortName": "it-IT-DiegoNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Animated",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, AlessioMultilingualNeural)",
+    "DisplayName": "Alessio Multilingual",
+    "LocalName": "Alessio Multilingual",
+    "ShortName": "it-IT-AlessioMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Warm",
+        "Gentle",
+        "Cheerful",
+        "Friendly"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, IsabellaMultilingualNeural)",
+    "DisplayName": "Isabella Multilingual",
+    "LocalName": "Isabella Multilingual",
+    "ShortName": "it-IT-IsabellaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Cheerful",
+        "Casual",
+        "Friendly",
+        "Pleasant"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, GiuseppeMultilingualNeural)",
+    "DisplayName": "Giuseppe Multilingual",
+    "LocalName": "Giuseppe Multilingual",
+    "ShortName": "it-IT-GiuseppeMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Advertisement",
+        "Social Media"
+      ],
+      "VoicePersonalities": [
+        "Expressive",
+        "Upbeat",
+        "Youthful"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, MarcelloMultilingualNeural)",
+    "DisplayName": "Marcello Multilingual",
+    "LocalName": "Marcello Multilingual",
+    "ShortName": "it-IT-MarcelloMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Friendly",
+        "Casual",
+        "Warm",
+        "Pleasant"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, BenignoNeural)",
+    "DisplayName": "Benigno",
+    "LocalName": "Benigno",
+    "ShortName": "it-IT-BenignoNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "153"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, CalimeroNeural)",
+    "DisplayName": "Calimero",
+    "LocalName": "Calimero",
+    "ShortName": "it-IT-CalimeroNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, CataldoNeural)",
+    "DisplayName": "Cataldo",
+    "LocalName": "Cataldo",
+    "ShortName": "it-IT-CataldoNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "149"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, FabiolaNeural)",
+    "DisplayName": "Fabiola",
+    "LocalName": "Fabiola",
+    "ShortName": "it-IT-FabiolaNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, FiammaNeural)",
+    "DisplayName": "Fiamma",
+    "LocalName": "Fiamma",
+    "ShortName": "it-IT-FiammaNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, GianniNeural)",
+    "DisplayName": "Gianni",
+    "LocalName": "Gianni",
+    "ShortName": "it-IT-GianniNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "139"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, GiuseppeNeural)",
+    "DisplayName": "Giuseppe",
+    "LocalName": "Giuseppe",
+    "ShortName": "it-IT-GiuseppeNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Warm"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, ImeldaNeural)",
+    "DisplayName": "Imelda",
+    "LocalName": "Imelda",
+    "ShortName": "it-IT-ImeldaNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "140"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, IrmaNeural)",
+    "DisplayName": "Irma",
+    "LocalName": "Irma",
+    "ShortName": "it-IT-IrmaNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, LisandroNeural)",
+    "DisplayName": "Lisandro",
+    "LocalName": "Lisandro",
+    "ShortName": "it-IT-LisandroNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "137"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, PalmiraNeural)",
+    "DisplayName": "Palmira",
+    "LocalName": "Palmira",
+    "ShortName": "it-IT-PalmiraNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "139"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, PierinaNeural)",
+    "DisplayName": "Pierina",
+    "LocalName": "Pierina",
+    "ShortName": "it-IT-PierinaNeural",
+    "Gender": "Female",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (it-IT, RinaldoNeural)",
+    "DisplayName": "Rinaldo",
+    "LocalName": "Rinaldo",
+    "ShortName": "it-IT-RinaldoNeural",
+    "Gender": "Male",
+    "Locale": "it-IT",
+    "LocaleName": "Italian (Italy)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "137"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (iu-Cans-CA, SiqiniqNeural)",
+    "DisplayName": "Siqiniq",
+    "LocalName": "ᓯᕿᓂᖅ",
+    "ShortName": "iu-Cans-CA-SiqiniqNeural",
+    "Gender": "Female",
+    "Locale": "iu-Cans-CA",
+    "LocaleName": "Inuktitut (Syllabics, Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "160"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (iu-Cans-CA, TaqqiqNeural)",
+    "DisplayName": "Taqqiq",
+    "LocalName": "ᑕᖅᑭᖅ",
+    "ShortName": "iu-Cans-CA-TaqqiqNeural",
+    "Gender": "Male",
+    "Locale": "iu-Cans-CA",
+    "LocaleName": "Inuktitut (Syllabics, Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "160"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (iu-Latn-CA, SiqiniqNeural)",
+    "DisplayName": "Siqiniq",
+    "LocalName": "ᓯᕿᓂᖅ",
+    "ShortName": "iu-Latn-CA-SiqiniqNeural",
+    "Gender": "Female",
+    "Locale": "iu-Latn-CA",
+    "LocaleName": "Inuktitut (Latin, Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "160"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (iu-Latn-CA, TaqqiqNeural)",
+    "DisplayName": "Taqqiq",
+    "LocalName": "ᑕᖅᑭᖅ",
+    "ShortName": "iu-Latn-CA-TaqqiqNeural",
+    "Gender": "Male",
+    "Locale": "iu-Latn-CA",
+    "LocaleName": "Inuktitut (Latin, Canada)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "160"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ja-JP, NanamiNeural)",
+    "DisplayName": "Nanami",
+    "LocalName": "七海",
+    "ShortName": "ja-JP-NanamiNeural",
+    "Gender": "Female",
+    "Locale": "ja-JP",
+    "LocaleName": "Japanese (Japan)",
+    "StyleList": [
+      "chat",
+      "customerservice",
+      "cheerful"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "305"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ja-JP, KeitaNeural)",
+    "DisplayName": "Keita",
+    "LocalName": "圭太",
+    "ShortName": "ja-JP-KeitaNeural",
+    "Gender": "Male",
+    "Locale": "ja-JP",
+    "LocaleName": "Japanese (Japan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Engaging"
+      ]
+    },
+    "WordsPerMinute": "337"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ja-JP, AoiNeural)",
+    "DisplayName": "Aoi",
+    "LocalName": "碧衣",
+    "ShortName": "ja-JP-AoiNeural",
+    "Gender": "Female",
+    "Locale": "ja-JP",
+    "LocaleName": "Japanese (Japan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "270"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ja-JP, DaichiNeural)",
+    "DisplayName": "Daichi",
+    "LocalName": "大智",
+    "ShortName": "ja-JP-DaichiNeural",
+    "Gender": "Male",
+    "Locale": "ja-JP",
+    "LocaleName": "Japanese (Japan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "312"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ja-JP, MayuNeural)",
+    "DisplayName": "Mayu",
+    "LocalName": "真夕",
+    "ShortName": "ja-JP-MayuNeural",
+    "Gender": "Female",
+    "Locale": "ja-JP",
+    "LocaleName": "Japanese (Japan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "302"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ja-JP, NaokiNeural)",
+    "DisplayName": "Naoki",
+    "LocalName": "直紀",
+    "ShortName": "ja-JP-NaokiNeural",
+    "Gender": "Male",
+    "Locale": "ja-JP",
+    "LocaleName": "Japanese (Japan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "312"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ja-JP, ShioriNeural)",
+    "DisplayName": "Shiori",
+    "LocalName": "志織",
+    "ShortName": "ja-JP-ShioriNeural",
+    "Gender": "Female",
+    "Locale": "ja-JP",
+    "LocaleName": "Japanese (Japan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "296"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (jv-ID, SitiNeural)",
+    "DisplayName": "Siti",
+    "LocalName": "Siti",
+    "ShortName": "jv-ID-SitiNeural",
+    "Gender": "Female",
+    "Locale": "jv-ID",
+    "LocaleName": "Javanese (Latin, Indonesia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "104"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (jv-ID, DimasNeural)",
+    "DisplayName": "Dimas",
+    "LocalName": "Dimas",
+    "ShortName": "jv-ID-DimasNeural",
+    "Gender": "Male",
+    "Locale": "jv-ID",
+    "LocaleName": "Javanese (Latin, Indonesia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "115"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ka-GE, EkaNeural)",
+    "DisplayName": "Eka",
+    "LocalName": "ეკა",
+    "ShortName": "ka-GE-EkaNeural",
+    "Gender": "Female",
+    "Locale": "ka-GE",
+    "LocaleName": "Georgian (Georgia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "104"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ka-GE, GiorgiNeural)",
+    "DisplayName": "Giorgi",
+    "LocalName": "გიორგი",
+    "ShortName": "ka-GE-GiorgiNeural",
+    "Gender": "Male",
+    "Locale": "ka-GE",
+    "LocaleName": "Georgian (Georgia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "104"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (kk-KZ, AigulNeural)",
+    "DisplayName": "Aigul",
+    "LocalName": "Айгүл",
+    "ShortName": "kk-KZ-AigulNeural",
+    "Gender": "Female",
+    "Locale": "kk-KZ",
+    "LocaleName": "Kazakh (Kazakhstan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "107"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (kk-KZ, DauletNeural)",
+    "DisplayName": "Daulet",
+    "LocalName": "Дәулет",
+    "ShortName": "kk-KZ-DauletNeural",
+    "Gender": "Male",
+    "Locale": "kk-KZ",
+    "LocaleName": "Kazakh (Kazakhstan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "111"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (km-KH, SreymomNeural)",
+    "DisplayName": "Sreymom",
+    "LocalName": "ស្រីមុំ",
+    "ShortName": "km-KH-SreymomNeural",
+    "Gender": "Female",
+    "Locale": "km-KH",
+    "LocaleName": "Khmer (Cambodia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "25"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (km-KH, PisethNeural)",
+    "DisplayName": "Piseth",
+    "LocalName": "ពិសិដ្ឋ",
+    "ShortName": "km-KH-PisethNeural",
+    "Gender": "Male",
+    "Locale": "km-KH",
+    "LocaleName": "Khmer (Cambodia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "25"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (kn-IN, SapnaNeural)",
+    "DisplayName": "Sapna",
+    "LocalName": "ಸಪ್ನಾ",
+    "ShortName": "kn-IN-SapnaNeural",
+    "Gender": "Female",
+    "Locale": "kn-IN",
+    "LocaleName": "Kannada (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "94"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (kn-IN, GaganNeural)",
+    "DisplayName": "Gagan",
+    "LocalName": "ಗಗನ್",
+    "ShortName": "kn-IN-GaganNeural",
+    "Gender": "Male",
+    "Locale": "kn-IN",
+    "LocaleName": "Kannada (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "100"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, SunHiNeural)",
+    "DisplayName": "Sun-Hi",
+    "LocalName": "선히",
+    "ShortName": "ko-KR-SunHiNeural",
+    "Gender": "Female",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Formal"
+      ]
+    },
+    "WordsPerMinute": "274"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, InJoonNeural)",
+    "DisplayName": "InJoon",
+    "LocalName": "인준",
+    "ShortName": "ko-KR-InJoonNeural",
+    "Gender": "Male",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "253"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, HyunsuMultilingualNeural)",
+    "DisplayName": "Hyunsu Multilingual",
+    "LocalName": "Hyunsu Multilingual",
+    "ShortName": "ko-KR-HyunsuMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Formal",
+        "Clear",
+        "Confident"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, BongJinNeural)",
+    "DisplayName": "BongJin",
+    "LocalName": "봉진",
+    "ShortName": "ko-KR-BongJinNeural",
+    "Gender": "Male",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "262"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, GookMinNeural)",
+    "DisplayName": "GookMin",
+    "LocalName": "국민",
+    "ShortName": "ko-KR-GookMinNeural",
+    "Gender": "Male",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "278"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, HyunsuNeural)",
+    "DisplayName": "Hyunsu",
+    "LocalName": "현수",
+    "ShortName": "ko-KR-HyunsuNeural",
+    "Gender": "Male",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Casual"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, JiMinNeural)",
+    "DisplayName": "JiMin",
+    "LocalName": "지민",
+    "ShortName": "ko-KR-JiMinNeural",
+    "Gender": "Female",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "291"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, SeoHyeonNeural)",
+    "DisplayName": "SeoHyeon",
+    "LocalName": "서현",
+    "ShortName": "ko-KR-SeoHyeonNeural",
+    "Gender": "Female",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "258"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, SoonBokNeural)",
+    "DisplayName": "SoonBok",
+    "LocalName": "순복",
+    "ShortName": "ko-KR-SoonBokNeural",
+    "Gender": "Female",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "271"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ko-KR, YuJinNeural)",
+    "DisplayName": "YuJin",
+    "LocalName": "유진",
+    "ShortName": "ko-KR-YuJinNeural",
+    "Gender": "Female",
+    "Locale": "ko-KR",
+    "LocaleName": "Korean (Korea)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "288"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (lo-LA, KeomanyNeural)",
+    "DisplayName": "Keomany",
+    "LocalName": "ແກ້ວມະນີ",
+    "ShortName": "lo-LA-KeomanyNeural",
+    "Gender": "Female",
+    "Locale": "lo-LA",
+    "LocaleName": "Lao (Laos)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "33"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (lo-LA, ChanthavongNeural)",
+    "DisplayName": "Chanthavong",
+    "LocalName": "ຈັນທະວົງ",
+    "ShortName": "lo-LA-ChanthavongNeural",
+    "Gender": "Male",
+    "Locale": "lo-LA",
+    "LocaleName": "Lao (Laos)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "35"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (lt-LT, OnaNeural)",
+    "DisplayName": "Ona",
+    "LocalName": "Ona",
+    "ShortName": "lt-LT-OnaNeural",
+    "Gender": "Female",
+    "Locale": "lt-LT",
+    "LocaleName": "Lithuanian (Lithuania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "107"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (lt-LT, LeonasNeural)",
+    "DisplayName": "Leonas",
+    "LocalName": "Leonas",
+    "ShortName": "lt-LT-LeonasNeural",
+    "Gender": "Male",
+    "Locale": "lt-LT",
+    "LocaleName": "Lithuanian (Lithuania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "111"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (lv-LV, EveritaNeural)",
+    "DisplayName": "Everita",
+    "LocalName": "Everita",
+    "ShortName": "lv-LV-EveritaNeural",
+    "Gender": "Female",
+    "Locale": "lv-LV",
+    "LocaleName": "Latvian (Latvia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "106"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (lv-LV, NilsNeural)",
+    "DisplayName": "Nils",
+    "LocalName": "Nils",
+    "ShortName": "lv-LV-NilsNeural",
+    "Gender": "Male",
+    "Locale": "lv-LV",
+    "LocaleName": "Latvian (Latvia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "120"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mk-MK, MarijaNeural)",
+    "DisplayName": "Marija",
+    "LocalName": "Марија",
+    "ShortName": "mk-MK-MarijaNeural",
+    "Gender": "Female",
+    "Locale": "mk-MK",
+    "LocaleName": "Macedonian (North Macedonia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "127"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mk-MK, AleksandarNeural)",
+    "DisplayName": "Aleksandar",
+    "LocalName": "Александар",
+    "ShortName": "mk-MK-AleksandarNeural",
+    "Gender": "Male",
+    "Locale": "mk-MK",
+    "LocaleName": "Macedonian (North Macedonia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "127"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ml-IN, SobhanaNeural)",
+    "DisplayName": "Sobhana",
+    "LocalName": "ശോഭന",
+    "ShortName": "ml-IN-SobhanaNeural",
+    "Gender": "Female",
+    "Locale": "ml-IN",
+    "LocaleName": "Malayalam (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "87"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ml-IN, MidhunNeural)",
+    "DisplayName": "Midhun",
+    "LocalName": "മിഥുൻ",
+    "ShortName": "ml-IN-MidhunNeural",
+    "Gender": "Male",
+    "Locale": "ml-IN",
+    "LocaleName": "Malayalam (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "93"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mn-MN, YesuiNeural)",
+    "DisplayName": "Yesui",
+    "LocalName": "Есүй",
+    "ShortName": "mn-MN-YesuiNeural",
+    "Gender": "Female",
+    "Locale": "mn-MN",
+    "LocaleName": "Mongolian (Mongolia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mn-MN, BataaNeural)",
+    "DisplayName": "Bataa",
+    "LocalName": "Батаа",
+    "ShortName": "mn-MN-BataaNeural",
+    "Gender": "Male",
+    "Locale": "mn-MN",
+    "LocaleName": "Mongolian (Mongolia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mr-IN, AarohiNeural)",
+    "DisplayName": "Aarohi",
+    "LocalName": "आरोही",
+    "ShortName": "mr-IN-AarohiNeural",
+    "Gender": "Female",
+    "Locale": "mr-IN",
+    "LocaleName": "Marathi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "99"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mr-IN, ManoharNeural)",
+    "DisplayName": "Manohar",
+    "LocalName": "मनोहर",
+    "ShortName": "mr-IN-ManoharNeural",
+    "Gender": "Male",
+    "Locale": "mr-IN",
+    "LocaleName": "Marathi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "100"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ms-MY, YasminNeural)",
+    "DisplayName": "Yasmin",
+    "LocalName": "Yasmin",
+    "ShortName": "ms-MY-YasminNeural",
+    "Gender": "Female",
+    "Locale": "ms-MY",
+    "LocaleName": "Malay (Malaysia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "112"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ms-MY, OsmanNeural)",
+    "DisplayName": "Osman",
+    "LocalName": "Osman",
+    "ShortName": "ms-MY-OsmanNeural",
+    "Gender": "Male",
+    "Locale": "ms-MY",
+    "LocaleName": "Malay (Malaysia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Gaming"
+      ],
+      "VoicePersonalities": [
+        "Whimsical",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "118"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mt-MT, GraceNeural)",
+    "DisplayName": "Grace",
+    "LocalName": "Grace",
+    "ShortName": "mt-MT-GraceNeural",
+    "Gender": "Female",
+    "Locale": "mt-MT",
+    "LocaleName": "Maltese (Malta)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "136"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (mt-MT, JosephNeural)",
+    "DisplayName": "Joseph",
+    "LocalName": "Joseph",
+    "ShortName": "mt-MT-JosephNeural",
+    "Gender": "Male",
+    "Locale": "mt-MT",
+    "LocaleName": "Maltese (Malta)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "130"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (my-MM, NilarNeural)",
+    "DisplayName": "Nilar",
+    "LocalName": "နီလာ",
+    "ShortName": "my-MM-NilarNeural",
+    "Gender": "Female",
+    "Locale": "my-MM",
+    "LocaleName": "Burmese (Myanmar)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "63"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (my-MM, ThihaNeural)",
+    "DisplayName": "Thiha",
+    "LocalName": "သီဟ",
+    "ShortName": "my-MM-ThihaNeural",
+    "Gender": "Male",
+    "Locale": "my-MM",
+    "LocaleName": "Burmese (Myanmar)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "71"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nb-NO, PernilleNeural)",
+    "DisplayName": "Pernille",
+    "LocalName": "Pernille",
+    "ShortName": "nb-NO-PernilleNeural",
+    "Gender": "Female",
+    "Locale": "nb-NO",
+    "LocaleName": "Norwegian Bokmål (Norway)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "160"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nb-NO, FinnNeural)",
+    "DisplayName": "Finn",
+    "LocalName": "Finn",
+    "ShortName": "nb-NO-FinnNeural",
+    "Gender": "Male",
+    "Locale": "nb-NO",
+    "LocaleName": "Norwegian Bokmål (Norway)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "145"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nb-NO, IselinNeural)",
+    "DisplayName": "Iselin",
+    "LocalName": "Iselin",
+    "ShortName": "nb-NO-IselinNeural",
+    "Gender": "Female",
+    "Locale": "nb-NO",
+    "LocaleName": "Norwegian Bokmål (Norway)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "154"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ne-NP, HemkalaNeural)",
+    "DisplayName": "Hemkala",
+    "LocalName": "हेमकला",
+    "ShortName": "ne-NP-HemkalaNeural",
+    "Gender": "Female",
+    "Locale": "ne-NP",
+    "LocaleName": "Nepali (Nepal)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "119"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ne-NP, SagarNeural)",
+    "DisplayName": "Sagar",
+    "LocalName": "सागर",
+    "ShortName": "ne-NP-SagarNeural",
+    "Gender": "Male",
+    "Locale": "ne-NP",
+    "LocaleName": "Nepali (Nepal)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "119"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nl-BE, DenaNeural)",
+    "DisplayName": "Dena",
+    "LocalName": "Dena",
+    "ShortName": "nl-BE-DenaNeural",
+    "Gender": "Female",
+    "Locale": "nl-BE",
+    "LocaleName": "Dutch (Belgium)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nl-BE, ArnaudNeural)",
+    "DisplayName": "Arnaud",
+    "LocalName": "Arnaud",
+    "ShortName": "nl-BE-ArnaudNeural",
+    "Gender": "Male",
+    "Locale": "nl-BE",
+    "LocaleName": "Dutch (Belgium)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nl-NL, FennaNeural)",
+    "DisplayName": "Fenna",
+    "LocalName": "Fenna",
+    "ShortName": "nl-NL-FennaNeural",
+    "Gender": "Female",
+    "Locale": "nl-NL",
+    "LocaleName": "Dutch (Netherlands)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Confident"
+      ]
+    },
+    "WordsPerMinute": "140"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nl-NL, MaartenNeural)",
+    "DisplayName": "Maarten",
+    "LocalName": "Maarten",
+    "ShortName": "nl-NL-MaartenNeural",
+    "Gender": "Male",
+    "Locale": "nl-NL",
+    "LocaleName": "Dutch (Netherlands)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Formal",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "151"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (nl-NL, ColetteNeural)",
+    "DisplayName": "Colette",
+    "LocalName": "Colette",
+    "ShortName": "nl-NL-ColetteNeural",
+    "Gender": "Female",
+    "Locale": "nl-NL",
+    "LocaleName": "Dutch (Netherlands)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "132"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (or-IN, SubhasiniNeural)",
+    "DisplayName": "Subhasini",
+    "LocalName": "ସୁଭାସିନୀ",
+    "ShortName": "or-IN-SubhasiniNeural",
+    "Gender": "Female",
+    "Locale": "or-IN",
+    "LocaleName": "Odia (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (or-IN, SukantNeural)",
+    "DisplayName": "Sukant",
+    "LocalName": "ସୁକାନ୍ତ",
+    "ShortName": "or-IN-SukantNeural",
+    "Gender": "Male",
+    "Locale": "or-IN",
+    "LocaleName": "Odia (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pa-IN, OjasNeural)",
+    "DisplayName": "Ojas",
+    "LocalName": "ਓਜਸ",
+    "ShortName": "pa-IN-OjasNeural",
+    "Gender": "Male",
+    "Locale": "pa-IN",
+    "LocaleName": "Punjabi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pa-IN, VaaniNeural)",
+    "DisplayName": "Vaani",
+    "LocalName": "ਵਾਨੀ",
+    "ShortName": "pa-IN-VaaniNeural",
+    "Gender": "Female",
+    "Locale": "pa-IN",
+    "LocaleName": "Punjabi (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pl-PL, AgnieszkaNeural)",
+    "DisplayName": "Agnieszka",
+    "LocalName": "Agnieszka",
+    "ShortName": "pl-PL-AgnieszkaNeural",
+    "Gender": "Female",
+    "Locale": "pl-PL",
+    "LocaleName": "Polish (Poland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "112"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pl-PL, MarekNeural)",
+    "DisplayName": "Marek",
+    "LocalName": "Marek",
+    "ShortName": "pl-PL-MarekNeural",
+    "Gender": "Male",
+    "Locale": "pl-PL",
+    "LocaleName": "Polish (Poland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pl-PL, ZofiaNeural)",
+    "DisplayName": "Zofia",
+    "LocalName": "Zofia",
+    "ShortName": "pl-PL-ZofiaNeural",
+    "Gender": "Female",
+    "Locale": "pl-PL",
+    "LocaleName": "Polish (Poland)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "127"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ps-AF, LatifaNeural)",
+    "DisplayName": "Latifa",
+    "LocalName": "لطيفه",
+    "ShortName": "ps-AF-LatifaNeural",
+    "Gender": "Female",
+    "Locale": "ps-AF",
+    "LocaleName": "Pashto (Afghanistan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "165"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ps-AF, GulNawazNeural)",
+    "DisplayName": "Gul Nawaz",
+    "LocalName": " ګل نواز",
+    "ShortName": "ps-AF-GulNawazNeural",
+    "Gender": "Male",
+    "Locale": "ps-AF",
+    "LocaleName": "Pashto (Afghanistan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "170"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, FranciscaNeural)",
+    "DisplayName": "Francisca",
+    "LocalName": "Francisca",
+    "ShortName": "pt-BR-FranciscaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "StyleList": [
+      "calm"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Crisp"
+      ]
+    },
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, AntonioNeural)",
+    "DisplayName": "Antonio",
+    "LocalName": "Antônio",
+    "ShortName": "pt-BR-AntonioNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, MacerioMultilingualNeural)",
+    "DisplayName": "Macerio Multilingual",
+    "LocalName": "Macerio Multilingual",
+    "ShortName": "pt-BR-MacerioMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Advertisement",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Clear",
+        "Confident",
+        "Upbeat"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, ThalitaMultilingualNeural)",
+    "DisplayName": "Thalita Multilingual",
+    "LocalName": "Thalita multilíngue",
+    "ShortName": "pt-BR-ThalitaMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Formal",
+        "Warm",
+        "Cheerful",
+        "Casual"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, BrendaNeural)",
+    "DisplayName": "Brenda",
+    "LocalName": "Brenda",
+    "ShortName": "pt-BR-BrendaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, DonatoNeural)",
+    "DisplayName": "Donato",
+    "LocalName": "Donato",
+    "ShortName": "pt-BR-DonatoNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "152"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, ElzaNeural)",
+    "DisplayName": "Elza",
+    "LocalName": "Elza",
+    "ShortName": "pt-BR-ElzaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, FabioNeural)",
+    "DisplayName": "Fabio",
+    "LocalName": "Fabio",
+    "ShortName": "pt-BR-FabioNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "134"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, GiovannaNeural)",
+    "DisplayName": "Giovanna",
+    "LocalName": "Giovanna",
+    "ShortName": "pt-BR-GiovannaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "143"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, HumbertoNeural)",
+    "DisplayName": "Humberto",
+    "LocalName": "Humberto",
+    "ShortName": "pt-BR-HumbertoNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "146"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, JulioNeural)",
+    "DisplayName": "Julio",
+    "LocalName": "Julio",
+    "ShortName": "pt-BR-JulioNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "136"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, LeilaNeural)",
+    "DisplayName": "Leila",
+    "LocalName": "Leila",
+    "ShortName": "pt-BR-LeilaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "153"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, LeticiaNeural)",
+    "DisplayName": "Leticia",
+    "LocalName": "Leticia",
+    "ShortName": "pt-BR-LeticiaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Curious",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, ManuelaNeural)",
+    "DisplayName": "Manuela",
+    "LocalName": "Manuela",
+    "ShortName": "pt-BR-ManuelaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, NicolauNeural)",
+    "DisplayName": "Nicolau",
+    "LocalName": "Nicolau",
+    "ShortName": "pt-BR-NicolauNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "132"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, ThalitaNeural)",
+    "DisplayName": "Thalita",
+    "LocalName": "Thalita",
+    "ShortName": "pt-BR-ThalitaNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Formal"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, ValerioNeural)",
+    "DisplayName": "Valerio",
+    "LocalName": "Valerio",
+    "ShortName": "pt-BR-ValerioNeural",
+    "Gender": "Male",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "131"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-BR, YaraNeural)",
+    "DisplayName": "Yara",
+    "LocalName": "Yara",
+    "ShortName": "pt-BR-YaraNeural",
+    "Gender": "Female",
+    "Locale": "pt-BR",
+    "LocaleName": "Portuguese (Brazil)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Well-Rounded",
+        "Animated",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "136"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-PT, RaquelNeural)",
+    "DisplayName": "Raquel",
+    "LocalName": "Raquel",
+    "ShortName": "pt-PT-RaquelNeural",
+    "Gender": "Female",
+    "Locale": "pt-PT",
+    "LocaleName": "Portuguese (Portugal)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Calm",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-PT, DuarteNeural)",
+    "DisplayName": "Duarte",
+    "LocalName": "Duarte",
+    "ShortName": "pt-PT-DuarteNeural",
+    "Gender": "Male",
+    "Locale": "pt-PT",
+    "LocaleName": "Portuguese (Portugal)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Serious",
+        "Deep"
+      ]
+    },
+    "WordsPerMinute": "182"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (pt-PT, FernandaNeural)",
+    "DisplayName": "Fernanda",
+    "LocalName": "Fernanda",
+    "ShortName": "pt-PT-FernandaNeural",
+    "Gender": "Female",
+    "Locale": "pt-PT",
+    "LocaleName": "Portuguese (Portugal)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "166"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ro-RO, AlinaNeural)",
+    "DisplayName": "Alina",
+    "LocalName": "Alina",
+    "ShortName": "ro-RO-AlinaNeural",
+    "Gender": "Female",
+    "Locale": "ro-RO",
+    "LocaleName": "Romanian (Romania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ro-RO, EmilNeural)",
+    "DisplayName": "Emil",
+    "LocalName": "Emil",
+    "ShortName": "ro-RO-EmilNeural",
+    "Gender": "Male",
+    "Locale": "ro-RO",
+    "LocaleName": "Romanian (Romania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "144"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ru-RU, SvetlanaNeural)",
+    "DisplayName": "Svetlana",
+    "LocalName": "Светлана",
+    "ShortName": "ru-RU-SvetlanaNeural",
+    "Gender": "Female",
+    "Locale": "ru-RU",
+    "LocaleName": "Russian (Russia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ru-RU, DmitryNeural)",
+    "DisplayName": "Dmitry",
+    "LocalName": "Дмитрий",
+    "ShortName": "ru-RU-DmitryNeural",
+    "Gender": "Male",
+    "Locale": "ru-RU",
+    "LocaleName": "Russian (Russia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ru-RU, DariyaNeural)",
+    "DisplayName": "Dariya",
+    "LocalName": "Дария",
+    "ShortName": "ru-RU-DariyaNeural",
+    "Gender": "Female",
+    "Locale": "ru-RU",
+    "LocaleName": "Russian (Russia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (si-LK, ThiliniNeural)",
+    "DisplayName": "Thilini",
+    "LocalName": "තිළිණි",
+    "ShortName": "si-LK-ThiliniNeural",
+    "Gender": "Female",
+    "Locale": "si-LK",
+    "LocaleName": "Sinhala (Sri Lanka)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "142"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (si-LK, SameeraNeural)",
+    "DisplayName": "Sameera",
+    "LocalName": "සමීර",
+    "ShortName": "si-LK-SameeraNeural",
+    "Gender": "Male",
+    "Locale": "si-LK",
+    "LocaleName": "Sinhala (Sri Lanka)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "155"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sk-SK, ViktoriaNeural)",
+    "DisplayName": "Viktoria",
+    "LocalName": "Viktória",
+    "ShortName": "sk-SK-ViktoriaNeural",
+    "Gender": "Female",
+    "Locale": "sk-SK",
+    "LocaleName": "Slovak (Slovakia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "118"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sk-SK, LukasNeural)",
+    "DisplayName": "Lukas",
+    "LocalName": "Lukáš",
+    "ShortName": "sk-SK-LukasNeural",
+    "Gender": "Male",
+    "Locale": "sk-SK",
+    "LocaleName": "Slovak (Slovakia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "132"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sl-SI, PetraNeural)",
+    "DisplayName": "Petra",
+    "LocalName": "Petra",
+    "ShortName": "sl-SI-PetraNeural",
+    "Gender": "Female",
+    "Locale": "sl-SI",
+    "LocaleName": "Slovenian (Slovenia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sl-SI, RokNeural)",
+    "DisplayName": "Rok",
+    "LocalName": "Rok",
+    "ShortName": "sl-SI-RokNeural",
+    "Gender": "Male",
+    "Locale": "sl-SI",
+    "LocaleName": "Slovenian (Slovenia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "126"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (so-SO, UbaxNeural)",
+    "DisplayName": "Ubax",
+    "LocalName": "Ubax",
+    "ShortName": "so-SO-UbaxNeural",
+    "Gender": "Female",
+    "Locale": "so-SO",
+    "LocaleName": "Somali (Somalia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "126"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (so-SO, MuuseNeural)",
+    "DisplayName": "Muuse",
+    "LocalName": "Muuse",
+    "ShortName": "so-SO-MuuseNeural",
+    "Gender": "Male",
+    "Locale": "so-SO",
+    "LocaleName": "Somali (Somalia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "136"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sq-AL, AnilaNeural)",
+    "DisplayName": "Anila",
+    "LocalName": "Anila",
+    "ShortName": "sq-AL-AnilaNeural",
+    "Gender": "Female",
+    "Locale": "sq-AL",
+    "LocaleName": "Albanian (Albania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sq-AL, IlirNeural)",
+    "DisplayName": "Ilir",
+    "LocalName": "Ilir",
+    "ShortName": "sq-AL-IlirNeural",
+    "Gender": "Male",
+    "Locale": "sq-AL",
+    "LocaleName": "Albanian (Albania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "141"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sr-Latn-RS, NicholasNeural)",
+    "DisplayName": "Nicholas",
+    "LocalName": "Nicholas",
+    "ShortName": "sr-Latn-RS-NicholasNeural",
+    "Gender": "Male",
+    "Locale": "sr-Latn-RS",
+    "LocaleName": "Serbian (Latin, Serbia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sr-Latn-RS, SophieNeural)",
+    "DisplayName": "Sophie",
+    "LocalName": "Sophie",
+    "ShortName": "sr-Latn-RS-SophieNeural",
+    "Gender": "Female",
+    "Locale": "sr-Latn-RS",
+    "LocaleName": "Serbian (Latin, Serbia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sr-RS, SophieNeural)",
+    "DisplayName": "Sophie",
+    "LocalName": "Софија",
+    "ShortName": "sr-RS-SophieNeural",
+    "Gender": "Female",
+    "Locale": "sr-RS",
+    "LocaleName": "Serbian (Cyrillic, Serbia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "132"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sr-RS, NicholasNeural)",
+    "DisplayName": "Nicholas",
+    "LocalName": "Никола",
+    "ShortName": "sr-RS-NicholasNeural",
+    "Gender": "Male",
+    "Locale": "sr-RS",
+    "LocaleName": "Serbian (Cyrillic, Serbia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "128"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (su-ID, TutiNeural)",
+    "DisplayName": "Tuti",
+    "LocalName": "Tuti",
+    "ShortName": "su-ID-TutiNeural",
+    "Gender": "Female",
+    "Locale": "su-ID",
+    "LocaleName": "Sundanese (Indonesia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "111"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (su-ID, JajangNeural)",
+    "DisplayName": "Jajang",
+    "LocalName": "Jajang",
+    "ShortName": "su-ID-JajangNeural",
+    "Gender": "Male",
+    "Locale": "su-ID",
+    "LocaleName": "Sundanese (Indonesia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "115"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sv-SE, SofieNeural)",
+    "DisplayName": "Sofie",
+    "LocalName": "Sofie",
+    "ShortName": "sv-SE-SofieNeural",
+    "Gender": "Female",
+    "Locale": "sv-SE",
+    "LocaleName": "Swedish (Sweden)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "138"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sv-SE, MattiasNeural)",
+    "DisplayName": "Mattias",
+    "LocalName": "Mattias",
+    "ShortName": "sv-SE-MattiasNeural",
+    "Gender": "Male",
+    "Locale": "sv-SE",
+    "LocaleName": "Swedish (Sweden)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "135"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sv-SE, HilleviNeural)",
+    "DisplayName": "Hillevi",
+    "LocalName": "Hillevi",
+    "ShortName": "sv-SE-HilleviNeural",
+    "Gender": "Female",
+    "Locale": "sv-SE",
+    "LocaleName": "Swedish (Sweden)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "147"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sw-KE, ZuriNeural)",
+    "DisplayName": "Zuri",
+    "LocalName": "Zuri",
+    "ShortName": "sw-KE-ZuriNeural",
+    "Gender": "Female",
+    "Locale": "sw-KE",
+    "LocaleName": "Swahili (Kenya)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "113"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sw-KE, RafikiNeural)",
+    "DisplayName": "Rafiki",
+    "LocalName": "Rafiki",
+    "ShortName": "sw-KE-RafikiNeural",
+    "Gender": "Male",
+    "Locale": "sw-KE",
+    "LocaleName": "Swahili (Kenya)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "121"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sw-TZ, RehemaNeural)",
+    "DisplayName": "Rehema",
+    "LocalName": "Rehema",
+    "ShortName": "sw-TZ-RehemaNeural",
+    "Gender": "Female",
+    "Locale": "sw-TZ",
+    "LocaleName": "Swahili (Tanzania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "108"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (sw-TZ, DaudiNeural)",
+    "DisplayName": "Daudi",
+    "LocalName": "Daudi",
+    "ShortName": "sw-TZ-DaudiNeural",
+    "Gender": "Male",
+    "Locale": "sw-TZ",
+    "LocaleName": "Swahili (Tanzania)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "114"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-IN, PallaviNeural)",
+    "DisplayName": "Pallavi",
+    "LocalName": "பல்லவி",
+    "ShortName": "ta-IN-PallaviNeural",
+    "Gender": "Female",
+    "Locale": "ta-IN",
+    "LocaleName": "Tamil (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "79"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-IN, ValluvarNeural)",
+    "DisplayName": "Valluvar",
+    "LocalName": "வள்ளுவர்",
+    "ShortName": "ta-IN-ValluvarNeural",
+    "Gender": "Male",
+    "Locale": "ta-IN",
+    "LocaleName": "Tamil (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "98"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-LK, SaranyaNeural)",
+    "DisplayName": "Saranya",
+    "LocalName": "சரண்யா",
+    "ShortName": "ta-LK-SaranyaNeural",
+    "Gender": "Female",
+    "Locale": "ta-LK",
+    "LocaleName": "Tamil (Sri Lanka)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "75"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-LK, KumarNeural)",
+    "DisplayName": "Kumar",
+    "LocalName": "குமார்",
+    "ShortName": "ta-LK-KumarNeural",
+    "Gender": "Male",
+    "Locale": "ta-LK",
+    "LocaleName": "Tamil (Sri Lanka)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "93"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-MY, KaniNeural)",
+    "DisplayName": "Kani",
+    "LocalName": "கனி",
+    "ShortName": "ta-MY-KaniNeural",
+    "Gender": "Female",
+    "Locale": "ta-MY",
+    "LocaleName": "Tamil (Malaysia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "83"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-MY, SuryaNeural)",
+    "DisplayName": "Surya",
+    "LocalName": "சூர்யா",
+    "ShortName": "ta-MY-SuryaNeural",
+    "Gender": "Male",
+    "Locale": "ta-MY",
+    "LocaleName": "Tamil (Malaysia)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "93"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-SG, VenbaNeural)",
+    "DisplayName": "Venba",
+    "LocalName": "வெண்பா",
+    "ShortName": "ta-SG-VenbaNeural",
+    "Gender": "Female",
+    "Locale": "ta-SG",
+    "LocaleName": "Tamil (Singapore)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "83"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ta-SG, AnbuNeural)",
+    "DisplayName": "Anbu",
+    "LocalName": "அன்பு",
+    "ShortName": "ta-SG-AnbuNeural",
+    "Gender": "Male",
+    "Locale": "ta-SG",
+    "LocaleName": "Tamil (Singapore)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "103"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (te-IN, ShrutiNeural)",
+    "DisplayName": "Shruti",
+    "LocalName": "శ్రుతి",
+    "ShortName": "te-IN-ShrutiNeural",
+    "Gender": "Female",
+    "Locale": "te-IN",
+    "LocaleName": "Telugu (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "79"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (te-IN, MohanNeural)",
+    "DisplayName": "Mohan",
+    "LocalName": "మోహన్",
+    "ShortName": "te-IN-MohanNeural",
+    "Gender": "Male",
+    "Locale": "te-IN",
+    "LocaleName": "Telugu (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "103"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (th-TH, PremwadeeNeural)",
+    "DisplayName": "Premwadee",
+    "LocalName": "เปรมวดี",
+    "ShortName": "th-TH-PremwadeeNeural",
+    "Gender": "Female",
+    "Locale": "th-TH",
+    "LocaleName": "Thai (Thailand)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "49"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (th-TH, NiwatNeural)",
+    "DisplayName": "Niwat",
+    "LocalName": "นิวัฒน์",
+    "ShortName": "th-TH-NiwatNeural",
+    "Gender": "Male",
+    "Locale": "th-TH",
+    "LocaleName": "Thai (Thailand)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "49"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (th-TH, AcharaNeural)",
+    "DisplayName": "Achara",
+    "LocalName": "อัจฉรา",
+    "ShortName": "th-TH-AcharaNeural",
+    "Gender": "Female",
+    "Locale": "th-TH",
+    "LocaleName": "Thai (Thailand)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "51"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (tr-TR, EmelNeural)",
+    "DisplayName": "Emel",
+    "LocalName": "Emel",
+    "ShortName": "tr-TR-EmelNeural",
+    "Gender": "Female",
+    "Locale": "tr-TR",
+    "LocaleName": "Turkish (Türkiye)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "111"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (tr-TR, AhmetNeural)",
+    "DisplayName": "Ahmet",
+    "LocalName": "Ahmet",
+    "ShortName": "tr-TR-AhmetNeural",
+    "Gender": "Male",
+    "Locale": "tr-TR",
+    "LocaleName": "Turkish (Türkiye)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "108"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (uk-UA, PolinaNeural)",
+    "DisplayName": "Polina",
+    "LocalName": "Поліна",
+    "ShortName": "uk-UA-PolinaNeural",
+    "Gender": "Female",
+    "Locale": "uk-UA",
+    "LocaleName": "Ukrainian (Ukraine)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "111"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (uk-UA, OstapNeural)",
+    "DisplayName": "Ostap",
+    "LocalName": "Остап",
+    "ShortName": "uk-UA-OstapNeural",
+    "Gender": "Male",
+    "Locale": "uk-UA",
+    "LocaleName": "Ukrainian (Ukraine)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "109"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ur-IN, GulNeural)",
+    "DisplayName": "Gul",
+    "LocalName": "گل",
+    "ShortName": "ur-IN-GulNeural",
+    "Gender": "Female",
+    "Locale": "ur-IN",
+    "LocaleName": "Urdu (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "157"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ur-IN, SalmanNeural)",
+    "DisplayName": "Salman",
+    "LocalName": "سلمان",
+    "ShortName": "ur-IN-SalmanNeural",
+    "Gender": "Male",
+    "Locale": "ur-IN",
+    "LocaleName": "Urdu (India)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "103"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ur-PK, UzmaNeural)",
+    "DisplayName": "Uzma",
+    "LocalName": "عظمیٰ",
+    "ShortName": "ur-PK-UzmaNeural",
+    "Gender": "Female",
+    "Locale": "ur-PK",
+    "LocaleName": "Urdu (Pakistan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "168"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (ur-PK, AsadNeural)",
+    "DisplayName": "Asad",
+    "LocalName": "اسد",
+    "ShortName": "ur-PK-AsadNeural",
+    "Gender": "Male",
+    "Locale": "ur-PK",
+    "LocaleName": "Urdu (Pakistan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "167"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (uz-UZ, MadinaNeural)",
+    "DisplayName": "Madina",
+    "LocalName": "Madina",
+    "ShortName": "uz-UZ-MadinaNeural",
+    "Gender": "Female",
+    "Locale": "uz-UZ",
+    "LocaleName": "Uzbek (Latin, Uzbekistan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "105"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (uz-UZ, SardorNeural)",
+    "DisplayName": "Sardor",
+    "LocalName": "Sardor",
+    "ShortName": "uz-UZ-SardorNeural",
+    "Gender": "Male",
+    "Locale": "uz-UZ",
+    "LocaleName": "Uzbek (Latin, Uzbekistan)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "112"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (vi-VN, HoaiMyNeural)",
+    "DisplayName": "HoaiMy",
+    "LocalName": "Hoài My",
+    "ShortName": "vi-VN-HoaiMyNeural",
+    "Gender": "Female",
+    "Locale": "vi-VN",
+    "LocaleName": "Vietnamese (Vietnam)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "202"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (vi-VN, NamMinhNeural)",
+    "DisplayName": "NamMinh",
+    "LocalName": "Nam Minh",
+    "ShortName": "vi-VN-NamMinhNeural",
+    "Gender": "Male",
+    "Locale": "vi-VN",
+    "LocaleName": "Vietnamese (Vietnam)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "204"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (wuu-CN, XiaotongNeural)",
+    "DisplayName": "Xiaotong",
+    "LocalName": "晓彤",
+    "ShortName": "wuu-CN-XiaotongNeural",
+    "Gender": "Female",
+    "Locale": "wuu-CN",
+    "LocaleName": "Chinese (Wu, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Friendly",
+        "Soothing"
+      ]
+    },
+    "WordsPerMinute": "238"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (wuu-CN, YunzheNeural)",
+    "DisplayName": "Yunzhe",
+    "LocalName": "云哲",
+    "ShortName": "wuu-CN-YunzheNeural",
+    "Gender": "Male",
+    "Locale": "wuu-CN",
+    "LocaleName": "Chinese (Wu, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Calm",
+        "Deep",
+        "Gentle"
+      ]
+    },
+    "WordsPerMinute": "244"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (yue-CN, XiaoMinNeural)",
+    "DisplayName": "XiaoMin",
+    "LocalName": "晓敏",
+    "ShortName": "yue-CN-XiaoMinNeural",
+    "Gender": "Female",
+    "Locale": "yue-CN",
+    "LocaleName": "Chinese (Cantonese, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Crisp",
+        "Confident"
+      ]
+    },
+    "WordsPerMinute": "214"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (yue-CN, YunSongNeural)",
+    "DisplayName": "YunSong",
+    "LocalName": "云松",
+    "ShortName": "yue-CN-YunSongNeural",
+    "Gender": "Male",
+    "Locale": "yue-CN",
+    "LocaleName": "Chinese (Cantonese, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Assistant"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Calm",
+        "Formal"
+      ]
+    },
+    "WordsPerMinute": "221"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoxiaoNeural)",
+    "DisplayName": "Xiaoxiao",
+    "LocalName": "晓晓",
+    "ShortName": "zh-CN-XiaoxiaoNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "assistant",
+      "chat",
+      "customerservice",
+      "newscast",
+      "affectionate",
+      "angry",
+      "calm",
+      "cheerful",
+      "disgruntled",
+      "fearful",
+      "gentle",
+      "lyrical",
+      "sad",
+      "serious",
+      "poetry-reading",
+      "friendly",
+      "chat-casual",
+      "whispering",
+      "sorry",
+      "excited"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Well-Rounded",
+        "Animated"
+      ]
+    },
+    "WordsPerMinute": "274"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunxiNeural)",
+    "DisplayName": "Yunxi",
+    "LocalName": "云希",
+    "ShortName": "zh-CN-YunxiNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "narration-relaxed",
+      "embarrassed",
+      "fearful",
+      "cheerful",
+      "disgruntled",
+      "serious",
+      "angry",
+      "sad",
+      "depressed",
+      "chat",
+      "assistant",
+      "newscast"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "RolePlayList": [
+      "Narrator",
+      "YoungAdultMale",
+      "Boy"
+    ],
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobooks"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Animated",
+        "Cheerful"
+      ]
+    },
+    "WordsPerMinute": "293"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunjianNeural)",
+    "DisplayName": "Yunjian",
+    "LocalName": "云健",
+    "ShortName": "zh-CN-YunjianNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "narration-relaxed",
+      "sports-commentary",
+      "sports-commentary-excited",
+      "angry",
+      "disgruntled",
+      "cheerful",
+      "sad",
+      "serious",
+      "depressed",
+      "documentary-narration"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Casual",
+        "Engaging"
+      ]
+    },
+    "WordsPerMinute": "279"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoyiNeural)",
+    "DisplayName": "Xiaoyi",
+    "LocalName": "晓伊",
+    "ShortName": "zh-CN-XiaoyiNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "angry",
+      "disgruntled",
+      "affectionate",
+      "cheerful",
+      "fearful",
+      "sad",
+      "embarrassed",
+      "serious",
+      "gentle"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobook"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Emotional",
+        "Engaging"
+      ]
+    },
+    "WordsPerMinute": "263"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunyangNeural)",
+    "DisplayName": "Yunyang",
+    "LocalName": "云扬",
+    "ShortName": "zh-CN-YunyangNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "customerservice",
+      "narration-professional",
+      "newscast-casual"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Formal",
+        "Deep",
+        "Calm"
+      ]
+    },
+    "WordsPerMinute": "293"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaochenNeural)",
+    "DisplayName": "Xiaochen",
+    "LocalName": "晓辰",
+    "ShortName": "zh-CN-XiaochenNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "livecommercial"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Friendly",
+        "Casual",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "283"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaochenMultilingualNeural)",
+    "DisplayName": "Xiaochen Multilingual",
+    "LocalName": "晓辰 多语言",
+    "ShortName": "zh-CN-XiaochenMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Friendly",
+        "Casual",
+        "Upbeat"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaohanNeural)",
+    "DisplayName": "Xiaohan",
+    "LocalName": "晓涵",
+    "ShortName": "zh-CN-XiaohanNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "calm",
+      "fearful",
+      "cheerful",
+      "disgruntled",
+      "serious",
+      "angry",
+      "sad",
+      "gentle",
+      "affectionate",
+      "embarrassed"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Gentle",
+        "Warm",
+        "Emotional"
+      ]
+    },
+    "WordsPerMinute": "259"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaomengNeural)",
+    "DisplayName": "Xiaomeng",
+    "LocalName": "晓梦",
+    "ShortName": "zh-CN-XiaomengNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "chat"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Gentle",
+        "Upbeat",
+        "Friendly"
+      ]
+    },
+    "WordsPerMinute": "272"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaomoNeural)",
+    "DisplayName": "Xiaomo",
+    "LocalName": "晓墨",
+    "ShortName": "zh-CN-XiaomoNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "embarrassed",
+      "calm",
+      "fearful",
+      "cheerful",
+      "disgruntled",
+      "serious",
+      "angry",
+      "sad",
+      "depressed",
+      "affectionate",
+      "gentle",
+      "envious"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "RolePlayList": [
+      "YoungAdultFemale",
+      "YoungAdultMale",
+      "OlderAdultFemale",
+      "OlderAdultMale",
+      "SeniorFemale",
+      "SeniorMale",
+      "Girl",
+      "Boy"
+    ],
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Casual",
+        "Calm"
+      ]
+    },
+    "WordsPerMinute": "286"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoqiuNeural)",
+    "DisplayName": "Xiaoqiu",
+    "LocalName": "晓秋",
+    "ShortName": "zh-CN-XiaoqiuNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Documentary"
+      ],
+      "VoicePersonalities": [
+        "Calm",
+        "Engaging",
+        "Soothing"
+      ]
+    },
+    "WordsPerMinute": "232"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaorouNeural)",
+    "DisplayName": "Xiaorou",
+    "LocalName": "晓柔",
+    "ShortName": "zh-CN-XiaorouNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Engaging",
+        "Pleasant"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoruiNeural)",
+    "DisplayName": "Xiaorui",
+    "LocalName": "晓睿",
+    "ShortName": "zh-CN-XiaoruiNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "calm",
+      "fearful",
+      "angry",
+      "sad"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Emotional",
+        "Hoarse"
+      ]
+    },
+    "WordsPerMinute": "243"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoshuangNeural)",
+    "DisplayName": "Xiaoshuang",
+    "LocalName": "晓双",
+    "ShortName": "zh-CN-XiaoshuangNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "chat"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobook"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Cheerful",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "225"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoxiaoDialectsNeural)",
+    "DisplayName": "Xiaoxiao Dialects",
+    "LocalName": "晓晓 方言",
+    "ShortName": "zh-CN-XiaoxiaoDialectsNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SecondaryLocaleList": [
+      "zh-CN-shaanxi",
+      "zh-CN-sichuan",
+      "zh-CN-shanxi",
+      "zh-CN-anhui",
+      "zh-CN-hunan",
+      "zh-CN-gansu",
+      "zh-CN-shandong",
+      "zh-CN-henan",
+      "zh-CN-liaoning",
+      "zh-TW",
+      "nan-CN",
+      "yue-CN",
+      "wuu-CN"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Animated",
+        "Bright"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoxiaoMultilingualNeural)",
+    "DisplayName": "Xiaoxiao Multilingual",
+    "LocalName": "晓晓 多语言",
+    "ShortName": "zh-CN-XiaoxiaoMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "affectionate",
+      "cheerful",
+      "empathetic",
+      "excited",
+      "poetry-reading",
+      "sorry",
+      "story"
+    ],
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Animated",
+        "Bright"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoyanNeural)",
+    "DisplayName": "Xiaoyan",
+    "LocalName": "晓颜",
+    "ShortName": "zh-CN-XiaoyanNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Assistant",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Gentle",
+        "Empathetic"
+      ]
+    },
+    "WordsPerMinute": "279"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoyouNeural)",
+    "DisplayName": "Xiaoyou",
+    "LocalName": "晓悠",
+    "ShortName": "zh-CN-XiaoyouNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Cheerful",
+        "Bright"
+      ]
+    },
+    "WordsPerMinute": "211"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoyuMultilingualNeural)",
+    "DisplayName": "Xiaoyu Multilingual",
+    "LocalName": "晓宇 多语言",
+    "ShortName": "zh-CN-XiaoyuMultilingualNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Confident",
+        "Casual"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaozhenNeural)",
+    "DisplayName": "Xiaozhen",
+    "LocalName": "晓甄",
+    "ShortName": "zh-CN-XiaozhenNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "angry",
+      "disgruntled",
+      "cheerful",
+      "fearful",
+      "sad",
+      "serious"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Audiobook"
+      ],
+      "VoicePersonalities": [
+        "Calm",
+        "Serious",
+        "Confident"
+      ]
+    },
+    "WordsPerMinute": "273"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunfengNeural)",
+    "DisplayName": "Yunfeng",
+    "LocalName": "云枫",
+    "ShortName": "zh-CN-YunfengNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "angry",
+      "disgruntled",
+      "cheerful",
+      "fearful",
+      "sad",
+      "serious",
+      "depressed"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Animated",
+        "Emotional"
+      ]
+    },
+    "WordsPerMinute": "320"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunhaoNeural)",
+    "DisplayName": "Yunhao",
+    "LocalName": "云皓",
+    "ShortName": "zh-CN-YunhaoNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "advertisement-upbeat"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Advertisement",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Warm",
+        "Soft",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "315"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunjieNeural)",
+    "DisplayName": "Yunjie",
+    "LocalName": "云杰",
+    "ShortName": "zh-CN-YunjieNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Confident",
+        "Warm"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunxiaNeural)",
+    "DisplayName": "Yunxia",
+    "LocalName": "云夏",
+    "ShortName": "zh-CN-YunxiaNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "calm",
+      "fearful",
+      "cheerful",
+      "angry",
+      "sad"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Chat"
+      ],
+      "VoicePersonalities": [
+        "Cheerful",
+        "Friendly",
+        "Emotional"
+      ]
+    },
+    "WordsPerMinute": "269"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunyeNeural)",
+    "DisplayName": "Yunye",
+    "LocalName": "云野",
+    "ShortName": "zh-CN-YunyeNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "embarrassed",
+      "calm",
+      "fearful",
+      "cheerful",
+      "disgruntled",
+      "serious",
+      "angry",
+      "sad"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "RolePlayList": [
+      "YoungAdultFemale",
+      "YoungAdultMale",
+      "OlderAdultFemale",
+      "OlderAdultMale",
+      "SeniorFemale",
+      "SeniorMale",
+      "Girl",
+      "Boy"
+    ],
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Audiobook",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Deep",
+        "Calm"
+      ]
+    },
+    "WordsPerMinute": "278"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunyiMultilingualNeural)",
+    "DisplayName": "Yunyi Multilingual",
+    "LocalName": "云逸 多语言",
+    "ShortName": "zh-CN-YunyiMultilingualNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "SecondaryLocaleList": [
+      "af-ZA",
+      "am-ET",
+      "ar-EG",
+      "ar-SA",
+      "az-AZ",
+      "bg-BG",
+      "bn-BD",
+      "bn-IN",
+      "bs-BA",
+      "ca-ES",
+      "cs-CZ",
+      "cy-GB",
+      "da-DK",
+      "de-AT",
+      "de-CH",
+      "de-DE",
+      "el-GR",
+      "en-AU",
+      "en-CA",
+      "en-GB",
+      "en-IE",
+      "en-IN",
+      "en-US",
+      "es-ES",
+      "es-MX",
+      "et-EE",
+      "eu-ES",
+      "fa-IR",
+      "fi-FI",
+      "fil-PH",
+      "fr-BE",
+      "fr-CA",
+      "fr-CH",
+      "fr-FR",
+      "ga-IE",
+      "gl-ES",
+      "he-IL",
+      "hi-IN",
+      "hr-HR",
+      "hu-HU",
+      "hy-AM",
+      "id-ID",
+      "is-IS",
+      "it-IT",
+      "ja-JP",
+      "jv-ID",
+      "ka-GE",
+      "kk-KZ",
+      "km-KH",
+      "kn-IN",
+      "ko-KR",
+      "lo-LA",
+      "lt-LT",
+      "lv-LV",
+      "mk-MK",
+      "ml-IN",
+      "mn-MN",
+      "ms-MY",
+      "mt-MT",
+      "my-MM",
+      "nb-NO",
+      "ne-NP",
+      "nl-BE",
+      "nl-NL",
+      "pl-PL",
+      "ps-AF",
+      "pt-BR",
+      "pt-PT",
+      "ro-RO",
+      "ru-RU",
+      "si-LK",
+      "sk-SK",
+      "sl-SI",
+      "so-SO",
+      "sq-AL",
+      "sr-RS",
+      "su-ID",
+      "sv-SE",
+      "sw-KE",
+      "ta-IN",
+      "te-IN",
+      "th-TH",
+      "tr-TR",
+      "uk-UA",
+      "ur-PK",
+      "uz-UZ",
+      "vi-VN",
+      "zh-CN",
+      "zh-HK",
+      "zh-TW",
+      "zu-ZA"
+    ],
+    "SampleRateHertz": "24000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Gentle",
+        "Casual",
+        "Friendly"
+      ]
+    }
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN, YunzeNeural)",
+    "DisplayName": "Yunze",
+    "LocalName": "云泽",
+    "ShortName": "zh-CN-YunzeNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN",
+    "LocaleName": "Chinese (Mandarin, Simplified)",
+    "StyleList": [
+      "calm",
+      "fearful",
+      "cheerful",
+      "disgruntled",
+      "serious",
+      "angry",
+      "sad",
+      "depressed",
+      "documentary-narration"
+    ],
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "RolePlayList": [
+      "OlderAdultMale",
+      "SeniorMale"
+    ],
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Documentary",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Deep",
+        "Confident",
+        "Formal"
+      ]
+    },
+    "WordsPerMinute": "255"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN-henan, YundengNeural)",
+    "DisplayName": "Yundeng",
+    "LocalName": "云登",
+    "ShortName": "zh-CN-henan-YundengNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN-henan",
+    "LocaleName": "Chinese (Zhongyuan Mandarin Henan, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Friendly",
+        "Animated"
+      ]
+    },
+    "WordsPerMinute": "285"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN-liaoning, XiaobeiNeural)",
+    "DisplayName": "Xiaobei",
+    "LocalName": "晓北",
+    "ShortName": "zh-CN-liaoning-XiaobeiNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN-liaoning",
+    "LocaleName": "Chinese (Northeastern Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Friendly",
+        "Casual",
+        "Gentle"
+      ]
+    },
+    "WordsPerMinute": "229"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN-shaanxi, XiaoniNeural)",
+    "DisplayName": "Xiaoni",
+    "LocalName": "晓妮",
+    "ShortName": "zh-CN-shaanxi-XiaoniNeural",
+    "Gender": "Female",
+    "Locale": "zh-CN-shaanxi",
+    "LocaleName": "Chinese (Zhongyuan Mandarin Shaanxi, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Confident",
+        "Engaging",
+        "Casual"
+      ]
+    },
+    "WordsPerMinute": "263"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN-shandong, YunxiangNeural)",
+    "DisplayName": "Yunxiang",
+    "LocalName": "云翔",
+    "ShortName": "zh-CN-shandong-YunxiangNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN-shandong",
+    "LocaleName": "Chinese (Jilu Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Animated",
+        "Strong"
+      ]
+    },
+    "WordsPerMinute": "279"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-CN-sichuan, YunxiNeural)",
+    "DisplayName": "YunxiSichuan",
+    "LocalName": "云希 四川",
+    "ShortName": "zh-CN-sichuan-YunxiNeural",
+    "Gender": "Male",
+    "Locale": "zh-CN-sichuan",
+    "LocaleName": "Chinese (Southwestern Mandarin, Simplified)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Chat",
+        "Podcast"
+      ],
+      "VoicePersonalities": [
+        "Casual",
+        "Animated",
+        "Gentle"
+      ]
+    },
+    "WordsPerMinute": "285"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-HK, HiuMaanNeural)",
+    "DisplayName": "HiuMaan",
+    "LocalName": "曉曼",
+    "ShortName": "zh-HK-HiuMaanNeural",
+    "Gender": "Female",
+    "Locale": "zh-HK",
+    "LocaleName": "Chinese (Cantonese, Traditional)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Bright",
+        "Upbeat"
+      ]
+    },
+    "WordsPerMinute": "244"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-HK, WanLungNeural)",
+    "DisplayName": "WanLung",
+    "LocalName": "雲龍",
+    "ShortName": "zh-HK-WanLungNeural",
+    "Gender": "Male",
+    "Locale": "zh-HK",
+    "LocaleName": "Chinese (Cantonese, Traditional)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Calm",
+        "Formal"
+      ]
+    },
+    "WordsPerMinute": "259"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-HK, HiuGaaiNeural)",
+    "DisplayName": "HiuGaai",
+    "LocalName": "曉佳",
+    "ShortName": "zh-HK-HiuGaaiNeural",
+    "Gender": "Female",
+    "Locale": "zh-HK",
+    "LocaleName": "Chinese (Cantonese, Traditional)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "194"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-TW, HsiaoChenNeural)",
+    "DisplayName": "HsiaoChen",
+    "LocalName": "曉臻",
+    "ShortName": "zh-TW-HsiaoChenNeural",
+    "Gender": "Female",
+    "Locale": "zh-TW",
+    "LocaleName": "Chinese (Taiwanese Mandarin, Traditional)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "Narration",
+        "News"
+      ],
+      "VoicePersonalities": [
+        "Soft",
+        "Caring"
+      ]
+    },
+    "WordsPerMinute": "272"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-TW, YunJheNeural)",
+    "DisplayName": "YunJhe",
+    "LocalName": "雲哲",
+    "ShortName": "zh-TW-YunJheNeural",
+    "Gender": "Male",
+    "Locale": "zh-TW",
+    "LocaleName": "Chinese (Taiwanese Mandarin, Traditional)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "Narration"
+      ],
+      "VoicePersonalities": [
+        "Engaging",
+        "Gentle"
+      ]
+    },
+    "WordsPerMinute": "285"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zh-TW, HsiaoYuNeural)",
+    "DisplayName": "HsiaoYu",
+    "LocalName": "曉雨",
+    "ShortName": "zh-TW-HsiaoYuNeural",
+    "Gender": "Female",
+    "Locale": "zh-TW",
+    "LocaleName": "Chinese (Taiwanese Mandarin, Traditional)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "VoiceTag": {
+      "TailoredScenarios": [
+        "News",
+        "E-learning"
+      ],
+      "VoicePersonalities": [
+        "Crisp",
+        "Bright",
+        "Clear"
+      ]
+    },
+    "WordsPerMinute": "223"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zu-ZA, ThandoNeural)",
+    "DisplayName": "Thando",
+    "LocalName": "Thando",
+    "ShortName": "zu-ZA-ThandoNeural",
+    "Gender": "Female",
+    "Locale": "zu-ZA",
+    "LocaleName": "Zulu (South Africa)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "83"
+  },
+  {
+    "Name": "Microsoft Server Speech Text to Speech Voice (zu-ZA, ThembaNeural)",
+    "DisplayName": "Themba",
+    "LocalName": "Themba",
+    "ShortName": "zu-ZA-ThembaNeural",
+    "Gender": "Male",
+    "Locale": "zu-ZA",
+    "LocaleName": "Zulu (South Africa)",
+    "SampleRateHertz": "48000",
+    "VoiceType": "Neural",
+    "Status": "GA",
+    "WordsPerMinute": "90"
+  }
+]


### PR DESCRIPTION
This pull request includes several changes to the `wyoming_microsoft_tts` package and its tests. The main improvements include adding a download directory configuration, removing outdated key validation, and enhancing voice transformation and retrieval.

Configuration and validation updates:

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R23): Added a `download_dir` parameter to the `microsoft_tts` configuration.
* [`wyoming_microsoft_tts/__main__.py`](diffhunk://#diff-28123cc871f3d90b2a54aab9472948e28f18e3e991efb435285bf60d6d79c1d9L83-L87): Removed the outdated subscription key validation logic.

Voice transformation and retrieval:

* [`wyoming_microsoft_tts/download.py`](diffhunk://#diff-9ebed3be293856700b12e85d0a541d88a1083aef4381b6ef3a73ac2aa5038f28R58-R76): Updated the `transform_voices_files` function to handle secondary locales and modified the `get_voices` function to use this transformation. [[1]](diffhunk://#diff-9ebed3be293856700b12e85d0a541d88a1083aef4381b6ef3a73ac2aa5038f28R58-R76) [[2]](diffhunk://#diff-9ebed3be293856700b12e85d0a541d88a1083aef4381b6ef3a73ac2aa5038f28L100-R119)

Codebase simplification:

* [`wyoming_microsoft_tts/__main__.py`](diffhunk://#diff-28123cc871f3d90b2a54aab9472948e28f18e3e991efb435285bf60d6d79c1d9L6): Removed an unused `import re` statement.

Integration with voice retrieval:

* [`wyoming_microsoft_tts/microsoft_tts.py`](diffhunk://#diff-744bf343f4a723b388b1b57ab4c1f5ab054def983e92bcf6098d0aa9a38f15f5R30-R39): Integrated the `get_voices` function to retrieve and use voice configurations during TTS synthesis. [[1]](diffhunk://#diff-744bf343f4a723b388b1b57ab4c1f5ab054def983e92bcf6098d0aa9a38f15f5R30-R39) [[2]](diffhunk://#diff-744bf343f4a723b388b1b57ab4c1f5ab054def983e92bcf6098d0aa9a38f15f5R9-R10)