### PR TITLE
test: only test for 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,6 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - name: "Install required packages"
@@ -28,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.13
 
     - name: "Install dependencies"
       run: |


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflow configuration for testing by removing the matrix strategy and standardizing the Python version used in the workflow.

Workflow simplification:

* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L14-L17): Removed the matrix strategy and its associated configurations, including parallelization and support for multiple Python versions (`3.11`, `3.12`, `3.13`).
* [`.github/workflows/test.yaml`](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L31-R27): Updated the Python setup step to use a fixed Python version (`3.13`) instead of referencing the matrix variable.