### PR TITLE
feat: add partial sentence synthesizing support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ black>=24,<26
 lxml>=5,<7
 pycountry>=23.12.11
 ruff
+regex

--- a/wyoming_microsoft_tts/__main__.py
+++ b/wyoming_microsoft_tts/__main__.py
@@ -61,6 +61,11 @@ def parse_arguments():
     parser.add_argument(
         "--auto-punctuation", default=".?!", help="Automatically add punctuation"
     )
+    parser.add_argument(
+        "--no-streaming",
+        action="store_true",
+        help="Disable audio streaming on sentence boundaries",
+    )
     parser.add_argument("--samples-per-chunk", type=int, default=1024)
     #
     parser.add_argument(
@@ -159,6 +164,7 @@ async def main() -> None:
                 installed=True,
                 version=__version__,
                 voices=sorted(voices, key=lambda v: v.name),
+                supports_synthesize_streaming=not args.no_streaming,
             )
         ],
     )

--- a/wyoming_microsoft_tts/handler.py
+++ b/wyoming_microsoft_tts/handler.py
@@ -62,7 +62,7 @@ class MicrosoftEventHandler(AsyncEventHandler):
                 synthesize.text = remove_asterisks(synthesize.text)
                 await self._handle_synthesize(synthesize)
 
-            if self.cli.no_streaming:
+            if self.cli_args.no_streaming:
                 return True
             
             if SynthesizeStart.is_type(event.type):

--- a/wyoming_microsoft_tts/handler.py
+++ b/wyoming_microsoft_tts/handler.py
@@ -4,15 +4,24 @@ import argparse
 import logging
 import math
 import os
+from typing import Optional
 import wave
 
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
+from wyoming.error import Error
 from wyoming.event import Event
 from wyoming.info import Describe, Info
 from wyoming.server import AsyncEventHandler
-from wyoming.tts import Synthesize
+from wyoming.tts import (
+    Synthesize,
+    SynthesizeChunk,
+    SynthesizeStart,
+    SynthesizeStop,
+    SynthesizeStopped,
+)
 
 from .microsoft_tts import MicrosoftTTS
+from .sentence_boundary import SentenceBoundaryDetector, remove_asterisks
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +42,9 @@ class MicrosoftEventHandler(AsyncEventHandler):
         self.cli_args = cli_args
         self.wyoming_info_event = wyoming_info.event()
         self.microsoft_tts = MicrosoftTTS(cli_args)
+        self.sbd = SentenceBoundaryDetector()
+        self.is_streaming: Optional[bool] = None
+        self._synthesize: Optional[Synthesize] = None
 
     async def handle_event(self, event: Event) -> bool:
         """Handle an event."""
@@ -41,13 +53,63 @@ class MicrosoftEventHandler(AsyncEventHandler):
             _LOGGER.debug("Sent info")
             return True
 
-        if not Synthesize.is_type(event.type):
-            _LOGGER.warning("Unexpected event: %s", event)
-            return True
+        try:
+            if Synthesize.is_type(event.type):
+                if self.is_streaming:
+                    return True
+                
+                synthesize = Synthesize.from_event(event)
+                synthesize.text = remove_asterisks(synthesize.text)
+                await self._handle_synthesize(synthesize)
 
-        synthesize = Synthesize.from_event(event)
+            if self.cli.no_streaming:
+                return True
+            
+            if SynthesizeStart.is_type(event.type):
+                # Start of a stream
+                stream_start = SynthesizeStart.from_event(event)
+                self.is_streaming = True
+                self.sbd = SentenceBoundaryDetector()
+                self._synthesize = Synthesize(text="", voice=stream_start.voice)
+                _LOGGER.debug("Text stream started: voice=%s", stream_start.voice)
+                return True
+            
+            if SynthesizeChunk.is_type(event.type):
+                assert self._synthesize is not None
+                stream_chunk = SynthesizeChunk.from_event(event)
+                for sentence in self.sbd.add_chunk(stream_chunk.text):
+                    _LOGGER.debug("Synthesizing stream sentence: %s", sentence)
+                    self._synthesize.text = sentence
+                    await self._handle_synthesize(self._synthesize)
+
+                return True
+            
+            if SynthesizeStop.is_type(event.type):
+                assert self._synthesize is not None
+                self._synthesize.text = self.sbd.finish()
+                if self._synthesize.text:
+                    # Final audio chunk(s)
+                    await self._handle_synthesize(self._synthesize)
+
+                # End of audio
+                await self.write_event(SynthesizeStopped().event())
+
+                _LOGGER.debug("Text stream stopped")
+                return True
+            
+            if not Synthesize.is_type(event.type):
+                return True
+            
+            synthesize = Synthesize.from_event(event)
+            return await self._handle_synthesize(synthesize)
+        except Exception as err:
+            await self.write_event(
+                Error(text=str(err), code=err.__class__.__name__).event()
+            )
+            raise err
+
+    async def _handle_synthesize(self, synthesize: Synthesize):
         _LOGGER.debug(synthesize)
-
         raw_text = synthesize.text
 
         # Join multiple lines

--- a/wyoming_microsoft_tts/sentence_boundary.py
+++ b/wyoming_microsoft_tts/sentence_boundary.py
@@ -1,0 +1,58 @@
+"""Guess the sentence boundaries in text."""
+
+from collections.abc import Iterable
+
+import regex as re
+
+SENTENCE_END = r"[.!?…]|[。！？]|[؟]|[।॥]"
+ABBREVIATION_RE = re.compile(r"\b\p{L}{1,3}\.$", re.UNICODE)
+
+SENTENCE_BOUNDARY_RE = re.compile(
+    rf"(.*?(?:{SENTENCE_END}+))(?=\s+[\p{{Lu}}\p{{Lt}}\p{{Lo}}]|(?:\s+\d+\.\s+))",
+    re.DOTALL,
+)
+WORD_ASTERISKS = re.compile(r"\*+([^\*]+)\*+")
+LINE_ASTERICKS = re.compile(r"(?<=^|\n)\s*\*+")
+
+
+class SentenceBoundaryDetector:
+    def __init__(self) -> None:
+        self.remaining_text = ""
+        self.current_sentence = ""
+
+    def add_chunk(self, chunk: str) -> Iterable[str]:
+        self.remaining_text += chunk
+        while self.remaining_text:
+            match = SENTENCE_BOUNDARY_RE.search(self.remaining_text)
+            if not match:
+                break
+
+            match_text = match.group(0)
+
+            if not self.current_sentence:
+                self.current_sentence = match_text
+            elif ABBREVIATION_RE.search(self.current_sentence[-5:]):
+                self.current_sentence += match_text
+            else:
+                yield remove_asterisks(self.current_sentence.strip())
+                self.current_sentence = match_text
+
+            if not ABBREVIATION_RE.search(self.current_sentence[-5:]):
+                yield remove_asterisks(self.current_sentence.strip())
+                self.current_sentence = ""
+
+            self.remaining_text = self.remaining_text[match.end() :]
+
+    def finish(self) -> str:
+        text = (self.current_sentence + self.remaining_text).strip()
+        self.remaining_text = ""
+        self.current_sentence = ""
+
+        return remove_asterisks(text)
+
+
+def remove_asterisks(text: str) -> str:
+    """Remove *asterisks* surrounding **words**"""
+    text = WORD_ASTERISKS.sub(r"\1", text)
+    text = LINE_ASTERICKS.sub("", text)
+    return text


### PR DESCRIPTION
This pull request introduces streaming support for text-to-speech synthesis, allowing audio to be streamed at sentence boundaries, and adds an option to disable streaming if desired. The main changes involve handling new streaming events, implementing sentence boundary detection, and updating the command-line interface to control streaming behavior.

**Streaming Support and Event Handling:**

* Added support for streaming TTS synthesis by handling `SynthesizeStart`, `SynthesizeChunk`, `SynthesizeStop`, and `SynthesizeStopped` events in `handler.py`. This enables audio to be synthesized and sent as sentences are detected, improving responsiveness for longer texts.
* Introduced a new `SentenceBoundaryDetector` class in `sentence_boundary.py` to accurately split incoming text into sentences for streaming synthesis.

**Configuration and CLI Improvements:**

* Added a `--no-streaming` command-line argument to allow users to disable streaming and revert to the original non-streaming behavior.
* Updated the info response to include the `supports_synthesize_streaming` flag, reflecting whether streaming is enabled or disabled.

**Internal Refactoring:**

* Refactored `handler.py` to manage streaming state, store partial synthesis data, and handle errors gracefully during event processing. [[1]](diffhunk://#diff-8398bf2f5247fe0b2943fcb5c4fc58c5adc5ec85984eba213047ab4895fa7e4eR45-R47) [[2]](diffhunk://#diff-8398bf2f5247fe0b2943fcb5c4fc58c5adc5ec85984eba213047ab4895fa7e4eR56-R112)