### PR TITLE
Add per-call SSML prosody/style overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,75 @@ python -m wyoming-microsoft-tts --<key> <value>
 | `samples-per-chunk` | Yes | Number of samples per audio chunk (default: 1024) |
 | `update-voices` | Yes | Download latest languages.json during startup |
 | `debug` | Yes | Log debug messages |
+| `rate` | Yes | Default speech rate (e.g., `+30%`, `0.5`, `fast`, `slow`) |
+| `pitch` | Yes | Default speech pitch (e.g., `+10%`, `high`, `low`, `+80Hz`) |
+| `volume` | Yes | Default speech volume (e.g., `+20%`, `loud`, `soft`, `75`) |
+| `style` | Yes | Default speaking style (e.g., `cheerful`, `sad`, `angry`, `calm`) |
+| `style-degree` | Yes | Default style intensity from `0.01` to `2` (default: `1`) |
+
+## Per-Call SSML Overrides from Home Assistant
+
+In addition to setting default prosody and style at the server level (via `--rate`, `--pitch`, `--volume`, `--style`, `--style-degree`), you can override these values **per TTS call** by embedding Azure SSML tags directly in the message text from Home Assistant. This works through the `tts.speak` action without any changes to the Home Assistant Wyoming integration.
+
+### Basic usage
+
+```yaml
+action: tts.speak
+target:
+  entity_id: tts.microsoft_tts
+data:
+  media_player_entity_id: media_player.living_room
+  message: "<prosody rate='+50%'>This is extra fast!</prosody>"
+```
+
+### Style override
+
+```yaml
+message: "<mstts:express-as style='cheerful'>Have a great day!</mstts:express-as>"
+```
+
+### Multiple tags in one message
+
+```yaml
+message: "<prosody rate='+50%'>URGENT</prosody> announcement: <prosody pitch='high'>heads up</prosody>"
+```
+
+### Hybrid mode — server defaults + per-call overrides
+
+When a `<prosody>` or `<mstts:express-as>` tag is found in the message text, the server **merges** its own defaults into the inline tags for any attribute **not already specified** on that tag. This gives you fine-grained control without repeating shared settings.
+
+**Example:** Server started with `--rate +30% --pitch low --volume +10% --style excited`
+
+```yaml
+message: "<prosody rate='+50%'>override rate only</prosody>"
+```
+
+In this call:
+- The inner `<prosody>` gets `rate="+50%"` (from message), `pitch="low"` and `volume="+10%"` (inherited from server defaults)
+- Azure supports nested `<prosody>` — the outer wrapper supplies the server defaults as a fallback, and the inner tag overrides only the attributes it specifies
+- Since no `<mstts:express-as>` is in the message, the server wraps the entire output with `<mstts:express-as style="excited">`
+
+### Complete SSML passthrough
+
+If you send a full SSML document (starting with `<speak`), it is passed to Azure **as-is**, ignoring all server defaults. This gives you complete control when needed:
+
+```yaml
+message: "<?xml version='1.0'?><speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'><voice name='en-US-JennyNeural'>Hello</voice></speak>"
+```
+
+### How merging works (edge cases)
+
+| Case | Behavior |
+|---|---|
+| Plain text, no CLI args | Sent as plain text to Azure (no SSML) |
+| Plain text, CLI args set | Wrapped with server defaults (existing behavior, unchanged) |
+| SSML fragment (`<prosody>`, `<mstts:express-as>`) | Parsed; missing attrs filled from server defaults; wrapped in `<speak>` + `<voice>` |
+| SSML fragment with invalid XML | Falls back to plain text treatment (server defaults applied) |
+| Complete `<speak>` document | Passed through as-is, server defaults ignored |
+| `<prosody>` in message + server prosody defaults | Nested `<prosody>`: outer has all server defaults, inner overrides specific attrs |
+| `<mstts:express-as>` in message + server style | Missing attrs (`style`, `styledegree`) injected inline; no outer wrapper added |
+| `<prosody>` in message, no server defaults | Used as-is with no additional wrapping |
+
+### Reference: Supported Azure SSML tags
+
+For the full list of supported styles, roles, prosody values, and SSML elements, see the [Microsoft SSML documentation](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-synthesis-markup-voice).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,41 @@
 """Fixtures for tests."""
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 import pytest
-from wyoming_microsoft_tts.microsoft_tts import MicrosoftTTS
+
+# Mock azure SDK (not available on all platforms) before importing the module
+import sys
+
+sys.modules["azure"] = MagicMock()
+sys.modules["azure.cognitiveservices"] = MagicMock()
+sys.modules["azure.cognitiveservices.speech"] = MagicMock()
+
+# Patch get_voices in download module to avoid network/voices.json dependency
+voices_fake_data = {
+    "en-US-JennyNeural": {
+        "key": "en-US-JennyNeural",
+        "language": {"code": "en-US"},
+        "name": "Jenny",
+    },
+    "en-GB-SoniaNeural": {
+        "key": "en-GB-SoniaNeural",
+        "language": {"code": "en-GB"},
+        "name": "Sonia",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def patch_get_voices():
+    """Patch get_voices to return known voices without network access."""
+    with patch("wyoming_microsoft_tts.microsoft_tts.get_voices", return_value=voices_fake_data):
+        yield
+
+
 import os
+
+from wyoming_microsoft_tts.microsoft_tts import MicrosoftTTS
 
 
 @pytest.fixture

--- a/tests/test_microsoft_tts.py
+++ b/tests/test_microsoft_tts.py
@@ -205,6 +205,249 @@ def test_build_ssml_voice_key_and_lang():
     assert '<voice name="en-GB-SoniaNeural">' in ssml
 
 
+# Per-Call SSML Fragment Tests
+
+
+def test_ssml_detection_no_tags():
+    """Test that plain text is not detected as SSML."""
+    assert not MicrosoftTTS._has_ssml_tags("Hello, world!")
+    assert not MicrosoftTTS._has_ssml_tags("x < 10 and y > 5")
+    assert not MicrosoftTTS._has_ssml_tags("")
+
+
+def test_ssml_detection_with_tags():
+    """Test that SSML tags are correctly detected."""
+    assert MicrosoftTTS._has_ssml_tags("<prosody rate='+50%'>hi</prosody>")
+    assert MicrosoftTTS._has_ssml_tags("prefix <prosody>hi</prosody> suffix")
+    assert MicrosoftTTS._has_ssml_tags("<mstts:express-as style='cheerful'>hi</mstts:express-as>")
+    assert MicrosoftTTS._has_ssml_tags("<break time='100ms'/>")
+    assert MicrosoftTTS._has_ssml_tags("<speak>hello</speak>")
+
+
+def test_complete_ssml_passthrough():
+    """Test that a complete SSML document is passed through as-is."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate=None, pitch=None, volume=None,
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml_doc = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis"'
+        ' xml:lang="en-US">'
+        '<voice name="en-US-JennyNeural">'
+        'Hello, world!'
+        '</voice>'
+        '</speak>'
+    )
+    result = tts._build_ssml(ssml_doc, "en-US-JennyNeural")
+    assert result == ssml_doc
+
+
+def test_complete_ssml_passthrough_minimal():
+    """Test that a minimal complete SSML (without XML declaration) passes through."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate=None, pitch=None, volume=None,
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml_doc = '<speak version="1.0"><voice name="x">hi</voice></speak>'
+    result = tts._build_ssml(ssml_doc, "en-US-JennyNeural")
+    assert result == ssml_doc
+
+
+def test_fragment_prosody_merge():
+    """Test server prosody defaults are injected into inline <prosody> tags."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate="+30%", pitch="low", volume=None,
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml(
+        '<prosody rate="+50%">fast</prosody>',
+        "en-US-JennyNeural",
+    )
+
+    assert '<?xml version="1.0" encoding="UTF-8"?>' in ssml
+    assert '<voice name="en-US-JennyNeural">' in ssml
+
+    # Server defaults wrap the fragment (nested prosody)
+    assert '<prosody rate="+30%" pitch="low">' in ssml
+    # Inline prosody keeps its own rate, gets server pitch injected
+    assert '<prosody rate="+50%" pitch="low">' in ssml or '<prosody pitch="low" rate="+50%">' in ssml
+    assert "fast" in ssml
+    assert '</prosody>' in ssml
+    assert '</voice>' in ssml
+
+
+def test_fragment_partial_prosody_override():
+    """Test message attr overrides server default for same attr, missing attrs inherit."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate="+30%", pitch="low", volume="+10%",
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml(
+        '<prosody rate="+50%">partial override</prosody>',
+        "en-US-JennyNeural",
+    )
+
+    # Middle wrapper has all server defaults
+    assert '<prosody rate="+30%" pitch="low" volume="+10%">' in ssml
+    # Inner overrides rate, gets pitch and volume from server
+    assert 'rate="+50%"' in ssml
+    assert 'pitch="low"' in ssml
+    assert 'volume="+10%"' in ssml
+    assert "partial override" in ssml
+
+
+def test_fragment_style_merge():
+    """Test server style defaults are injected into inline <mstts:express-as>."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate=None, pitch=None, volume=None,
+        style="cheerful", style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml(
+        '<mstts:express-as style="sad">feeling sad</mstts:express-as>',
+        "en-US-JennyNeural",
+    )
+
+    assert 'xmlns:mstts="https://www.w3.org/2001/mstts"' in ssml
+    # Inline style overrides — should have style="sad" from message, NOT cheerful from server
+    assert '<mstts:express-as style="sad">' in ssml or '<mstts:express-as style="sad">' in ssml
+    assert "feeling sad" in ssml
+    # No outer express-as wrapper since inline one exists
+    assert ssml.count("mstts:express-as") == 2  # open + close
+
+
+def test_fragment_style_with_degree_partial_override():
+    """Test style_degree is injected when message only specifies style."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate=None, pitch=None, volume=None,
+        style="cheerful", style_degree=1.5,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml(
+        '<mstts:express-as style="sad">mixed style</mstts:express-as>',
+        "en-US-JennyNeural",
+    )
+
+    # style should be "sad" from message, styledegree should be "1.5" from server
+    assert 'style="sad"' in ssml
+    assert 'styledegree="1.5"' in ssml
+    assert "mixed style" in ssml
+
+
+def test_fragment_prosody_and_style():
+    """Test both prosody and style fragments are merged correctly."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate="fast", pitch=None, volume=None,
+        style="excited", style_degree=1.2,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml(
+        '<prosody rate="slow">dramatic pause</prosody>',
+        "en-US-JennyNeural",
+    )
+
+    # Style wrapper from server (no inline style, so it gets added)
+    assert '<mstts:express-as style="excited" styledegree="1.2">' in ssml
+    # Prosody wrapper from server
+    assert '<prosody rate="fast">' in ssml
+    # Inner prosody overrides rate
+    assert '<prosody rate="slow">' in ssml
+    assert "dramatic pause" in ssml
+
+
+def test_plain_text_without_server_defaults():
+    """Test plain text without any server defaults stays plain text (no SSML wrapping)."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate=None, pitch=None, volume=None,
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml("Hello, world!", "en-US-JennyNeural")
+
+    # Plain text without CLI args goes through the plain SSML builder
+    assert '<?xml version="1.0" encoding="UTF-8"?>' in ssml
+    assert '<speak version="1.0"' in ssml
+    assert '<voice name="en-US-JennyNeural">' in ssml
+    assert 'Hello, world!' in ssml
+    assert '<prosody' not in ssml
+    assert '<mstts:express-as' not in ssml
+
+
+def test_ssml_fragment_without_server_defaults():
+    """Test SSML fragment is processed correctly even without any server defaults."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate=None, pitch=None, volume=None,
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml(
+        '<prosody rate="+50%">no server defaults</prosody>',
+        "en-US-JennyNeural",
+    )
+
+    # No server prosody or style, so no wrapper should be added
+    assert '<prosody rate="+50%">' in ssml
+    assert "no server defaults" in ssml
+    # No outer prosody wrapper since no server defaults
+    # Inner prosody should be the only one (or none wrapping it)
+    assert "xmlns:mstts" not in ssml
+
+
+def test_invalid_xml_fragment_falls_back():
+    """Test that text looking like SSML but with invalid XML falls back to plain text."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate="+30%", pitch=None, volume=None,
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    # This has an unclosed tag, making it invalid XML
+    ssml = tts._build_ssml(
+        '<prosody rate="+50%">unclosed',
+        "en-US-JennyNeural",
+    )
+
+    # Falls back to plain text wrapping with server defaults
+    assert '<prosody rate="+30%">' in ssml
+    assert "unclosed" in ssml
+
+
+def test_mixed_ssml_fragment_with_plain_text():
+    """Test fragment with inline prosody and surrounding plain text."""
+    args = SimpleNamespace(
+        subscription_key=None, service_region=None, download_dir="/tmp/",
+        voice="en-US-JennyNeural", rate="+30%", pitch=None, volume=None,
+        style=None, style_degree=None,
+    )
+    tts = MicrosoftTTS(args)
+    ssml = tts._build_ssml(
+        '<prosody rate="+50%">emphasized</prosody> normal text',
+        "en-US-JennyNeural",
+    )
+
+    # Outer prosody wrapping everything
+    assert '<prosody rate="+30%">' in ssml
+    # Inner prosody with rate override + inherited from outer
+    assert '<prosody rate="+50%">' in ssml
+    assert "emphasized" in ssml
+    assert "normal text" in ssml
+    assert ssml.count('</prosody>') == 2  # inner + outer
+
+
 # Integration Tests with Synthesize
 
 

--- a/wyoming_microsoft_tts/handler.py
+++ b/wyoming_microsoft_tts/handler.py
@@ -120,15 +120,17 @@ class MicrosoftEventHandler(AsyncEventHandler):
             voice = synthesize.voice.name
 
         if self.cli_args.auto_punctuation and text:
-            # Add automatic punctuation (important for some voices)
-            has_punctuation = False
-            for punc_char in self.cli_args.auto_punctuation:
-                if text[-1] == punc_char:
-                    has_punctuation = True
-                    break
+            # Skip auto-punctuation when message contains SSML markup
+            if '<' not in text:
+                # Add automatic punctuation (important for some voices)
+                has_punctuation = False
+                for punc_char in self.cli_args.auto_punctuation:
+                    if text[-1] == punc_char:
+                        has_punctuation = True
+                        break
 
-            if not has_punctuation:
-                text = text + self.cli_args.auto_punctuation[0]
+                if not has_punctuation:
+                    text = text + self.cli_args.auto_punctuation[0]
 
         _LOGGER.debug("Synthesizing: %s", text)
         try:

--- a/wyoming_microsoft_tts/microsoft_tts.py
+++ b/wyoming_microsoft_tts/microsoft_tts.py
@@ -1,8 +1,10 @@
 """Microsoft TTS."""
 
 import logging
+import re
 import tempfile
 import time
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import azure.cognitiveservices.speech as speechsdk
@@ -10,6 +12,10 @@ import azure.cognitiveservices.speech as speechsdk
 from .download import get_voices
 
 _LOGGER = logging.getLogger(__name__)
+
+_SSML_TAG_RE = re.compile(r"</?([\w:-]+)(?:\s[^>]*)?>")
+
+ET.register_namespace("mstts", "https://www.w3.org/2001/mstts")
 
 
 class MicrosoftTTS:
@@ -30,21 +36,150 @@ class MicrosoftTTS:
 
         self.voices = get_voices(args.download_dir)
 
+    @staticmethod
+    def _has_ssml_tags(text: str) -> bool:
+        """Check if text contains SSML markup tags."""
+        return bool(_SSML_TAG_RE.search(text))
+
+    @staticmethod
+    def _is_complete_ssml(text: str) -> bool:
+        """Check if text is a complete SSML document (starts with <speak or <?xml)."""
+        stripped = text.strip()
+        return stripped.startswith("<speak") or stripped.startswith("<?xml")
+
     def _build_ssml(self, text, voice):
-        """Build SSML with prosody and style parameters."""
+        """Build SSML with prosody and style parameters.
+
+        Handles three cases:
+        1. Complete SSML document — passed through as-is
+        2. SSML fragment — server defaults merged into inline tags
+        3. Plain text — existing behavior (wraps with server defaults)
+        """
         voice_key = self.voices[voice]["key"]
         voice_lang = self.voices[voice]["language"]["code"]
 
-        ssml_parts = [
+        if self._is_complete_ssml(text):
+            return text
+
+        if self._has_ssml_tags(text):
+            merged = self._merge_ssml_fragment(text)
+            if merged is not None:
+                return self._build_ssml_structure(merged, voice_key, voice_lang)
+
+        return self._build_ssml_plain(text, voice_key, voice_lang)
+
+    def _merge_ssml_fragment(self, text: str) -> str | None:
+        """Parse SSML fragment and merge server defaults into inline tags.
+
+        For each <prosody> tag: injects server rate/pitch/volume for any
+        attribute not already set on the tag.
+        For each <mstts:express-as> tag: injects server style/style_degree
+        for any attribute not already set on the tag.
+        """
+        try:
+            wrapped = f'<root xmlns:mstts="https://www.w3.org/2001/mstts">{text}</root>'
+            root = ET.fromstring(wrapped)
+        except ET.ParseError:
+            return None
+
+        ns_mstts = "https://www.w3.org/2001/mstts"
+
+        for elem in root.iter():
+            if elem.tag == "prosody":
+                if self.args.rate and "rate" not in elem.attrib:
+                    elem.set("rate", self.args.rate)
+                if self.args.pitch and "pitch" not in elem.attrib:
+                    elem.set("pitch", self.args.pitch)
+                if self.args.volume and "volume" not in elem.attrib:
+                    elem.set("volume", self.args.volume)
+
+            if elem.tag == f"{{{ns_mstts}}}express-as":
+                if self.args.style and "style" not in elem.attrib:
+                    elem.set("style", self.args.style)
+                if self.args.style_degree is not None and "styledegree" not in elem.attrib:
+                    elem.set("styledegree", str(self.args.style_degree))
+
+        result = ET.tostring(root, encoding="unicode")
+        close = result.index(">") + 1
+        return result[close : -len("</root>")]
+
+    def _get_style_attrs(self):
+        """Build style attribute list from server args."""
+        attrs = []
+        if self.args.style is not None:
+            attrs.append(f'style="{self.args.style}"')
+        if self.args.style_degree is not None:
+            attrs.append(f'styledegree="{self.args.style_degree}"')
+        return attrs
+
+    def _get_prosody_attrs(self):
+        """Build prosody attribute list from server args."""
+        attrs = []
+        if self.args.rate:
+            attrs.append(f'rate="{self.args.rate}"')
+        if self.args.pitch:
+            attrs.append(f'pitch="{self.args.pitch}"')
+        if self.args.volume:
+            attrs.append(f'volume="{self.args.volume}"')
+        return attrs
+
+    def _build_ssml_structure(self, inner_content, voice_key, voice_lang):
+        """Wrap inner content in SSML structure with server-level defaults.
+
+        The inner content may contain inline prosody/style tags that were
+        already merged with server defaults. Server-level wrappers are added
+        for attributes not covered inline:
+        - <prosody> wrapper always added if server has rate/pitch/volume
+          (Azure supports nested <prosody>; inner overrides outer per-attribute)
+        - <mstts:express-as> wrapper added only if no inline style tag exists
+        """
+        has_style = self.args.style is not None or self.args.style_degree is not None
+        has_prosody = any([self.args.rate, self.args.pitch, self.args.volume])
+        has_inline_style = "<mstts:express-as" in inner_content
+
+        parts = [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis"',
+        ]
+
+        if has_style or has_inline_style:
+            parts.append(' xmlns:mstts="https://www.w3.org/2001/mstts"')
+
+        parts.append(f' xml:lang="{voice_lang}">')
+        parts.append(f'<voice name="{voice_key}">')
+
+        if has_style and not has_inline_style:
+            style_attrs = self._get_style_attrs()
+            parts.append(f'<mstts:express-as {" ".join(style_attrs)}>')
+
+        if has_prosody:
+            prosody_attrs = self._get_prosody_attrs()
+            parts.append(f'<prosody {" ".join(prosody_attrs)}>')
+
+        parts.append(inner_content)
+
+        if has_prosody:
+            parts.append("</prosody>")
+        if has_style and not has_inline_style:
+            parts.append("</mstts:express-as>")
+
+        parts.append("</voice>")
+        parts.append("</speak>")
+
+        return "".join(parts)
+
+    def _build_ssml_plain(self, text, voice_key, voice_lang):
+        """Build SSML for plain text using only server-level defaults."""
+        parts = [
             '<?xml version="1.0" encoding="UTF-8"?>',
             '<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis"',
         ]
 
         if self.args.style or self.args.style_degree:
-            ssml_parts.append(' xmlns:mstts="https://www.w3.org/2001/mstts"')
+            parts.append(' xmlns:mstts="https://www.w3.org/2001/mstts"')
 
-        ssml_parts.append(f' xml:lang="{voice_lang}">')
-        ssml_parts.append(f'<voice name="{voice_key}">')
+        parts.append(f' xml:lang="{voice_lang}">')
+        parts.append(f'<voice name="{voice_key}">')
 
         has_style = self.args.style is not None
         has_prosody = any([self.args.rate, self.args.pitch, self.args.volume])
@@ -53,7 +188,7 @@ class MicrosoftTTS:
             style_attrs = [f'style="{self.args.style}"']
             if self.args.style_degree is not None:
                 style_attrs.append(f'styledegree="{self.args.style_degree}"')
-            ssml_parts.append(f'<mstts:express-as {" ".join(style_attrs)}>')
+            parts.append(f'<mstts:express-as {" ".join(style_attrs)}>')
 
         if has_prosody:
             prosody_attrs = []
@@ -63,20 +198,20 @@ class MicrosoftTTS:
                 prosody_attrs.append(f'pitch="{self.args.pitch}"')
             if self.args.volume:
                 prosody_attrs.append(f'volume="{self.args.volume}"')
-            ssml_parts.append(f'<prosody {" ".join(prosody_attrs)}>')
+            parts.append(f'<prosody {" ".join(prosody_attrs)}>')
 
-        ssml_parts.append(text)
+        parts.append(text)
 
         if has_prosody:
-            ssml_parts.append('</prosody>')
+            parts.append("</prosody>")
 
         if has_style:
-            ssml_parts.append('</mstts:express-as>')
+            parts.append("</mstts:express-as>")
 
-        ssml_parts.append('</voice>')
-        ssml_parts.append('</speak>')
+        parts.append("</voice>")
+        parts.append("</speak>")
 
-        return ''.join(ssml_parts)
+        return "".join(parts)
 
     def synthesize(self, text, voice=None):
         """Synthesize text to speech."""
@@ -94,7 +229,7 @@ class MicrosoftTTS:
             speech_config=self.speech_config, audio_config=audio_config
         )
 
-        if any([self.args.rate, self.args.pitch, self.args.volume, self.args.style, self.args.style_degree]):
+        if any([self.args.rate, self.args.pitch, self.args.volume, self.args.style, self.args.style_degree]) or self._has_ssml_tags(text):
             ssml = self._build_ssml(text, voice)
             _LOGGER.debug(f"Using SSML: {ssml}")
             speech_synthesis_result = speech_synthesizer.speak_ssml_async(ssml).get()


### PR DESCRIPTION
Add per-call SSML prosody/style overrides

Embed Azure SSML tags (<prosody>, <mstts:express-as>) directly in the message text to override server-level defaults per TTS call.

- _is_complete_ssml: complete <speak> docs pass through as-is
- _merge_ssml_fragment: parse fragment with xml.etree.ElementTree, inject server defaults for any attribute not specified inline
- _build_ssml_structure: wrap merged content in <speak>/<voice>; add server-level <prosody> (nested, always) and <mstts:express-as> (only if no inline style tag exists)
- _build_ssml_plain: extracted from original _build_ssml (no behavioral change)
- synthesize: enter SSML path when message contains SSML tags even without any server CLI defaults
- Tests: 13 new cases for detection, passthrough, merge, fallback
- README: document per-call overrides, hybrid mode, edge cases

Developed with OpenCode (deepseek-v4-flash-free, explore+general agents)